### PR TITLE
Cache models and improve resource handling

### DIFF
--- a/archiver.py
+++ b/archiver.py
@@ -4,15 +4,15 @@ from config import settings
 from schemas import Conversation
 
 logger = logging.getLogger(__name__)
-client = pymongo.MongoClient(settings.safe_mongo_uri)
-db = client.get_database("MentalHealthDB")
-conversations_collection = db['PatientConvo']
 
 def archive_conversation(conversation: Conversation):
     conv_dict = conversation.dict()
-    conversations_collection.replace_one(
-        {"session_id": conversation.session_id},
-        conv_dict,
-        upsert=True
-    )
+    with pymongo.MongoClient(settings.safe_mongo_uri) as client:
+        db = client.get_database("MentalHealthDB")
+        conversations_collection = db['PatientConvo']
+        conversations_collection.replace_one(
+            {"session_id": conversation.session_id},
+            conv_dict,
+            upsert=True
+        )
     logger.info("Conversation %s archived successfully.", conversation.session_id)

--- a/llm_rag.py
+++ b/llm_rag.py
@@ -1,8 +1,7 @@
 import logging
-from langchain_groq import ChatGroq
 from langchain.schema import HumanMessage
-from config import settings
 from semantic_search import semantic_search
+from model_cache import get_chat_groq
 
 logger = logging.getLogger(__name__)
 
@@ -13,17 +12,13 @@ def generate_advice(query: str):
     examples_text = ""
     for ex in examples:
          examples_text += f"Patient: {ex.get('questionText', '')}\nTherapist: {ex.get('answerText', '')}\n\n"
-    
+
     prompt = f"""You are a mental health counselor. Based on the following examples, suggest advice:
 Examples:
 {examples_text}
 New Query: {query}
 Advice:"""
-    llm = ChatGroq(
-         temperature=0.7,
-         model_name="llama-3.3-70b-versatile",
-         groq_api_key=settings.groq_api_key
-    )
+    llm = get_chat_groq()
     response = llm.invoke([HumanMessage(content=prompt)])
     logger.debug("Advice generated: %s", response)
     return response

--- a/model_cache.py
+++ b/model_cache.py
@@ -1,0 +1,18 @@
+from functools import lru_cache
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain_groq import ChatGroq
+from config import settings
+
+@lru_cache(maxsize=1)
+def get_embedding_model():
+    """Return a cached embedding model instance."""
+    return HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+@lru_cache(maxsize=1)
+def get_chat_groq():
+    """Return a cached ChatGroq instance."""
+    return ChatGroq(
+        temperature=0.7,
+        model_name="llama-3.3-70b-versatile",
+        groq_api_key=settings.groq_api_key,
+    )

--- a/patient_profile.py
+++ b/patient_profile.py
@@ -2,8 +2,8 @@ import time
 import pymongo
 import logging
 from config import settings
-from langchain_huggingface import HuggingFaceEmbeddings
 from pinecone import Pinecone, ServerlessSpec
+from model_cache import get_embedding_model
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ def update_patient_profile(patient_id: str):
         return
     profile_text = "\n".join(patient_texts)
 
-    embedding_model = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+    embedding_model = get_embedding_model()
     embedding = embedding_model.embed_query(profile_text)
 
     pc = Pinecone(api_key=settings.pinecone_api_key)

--- a/schemas.py
+++ b/schemas.py
@@ -11,7 +11,7 @@ class Message(BaseModel):
 class Conversation(BaseModel):
     session_id: str
     patient_id: str = ""  # Patient identifier
-    messages: List[Message] = []
+    messages: List[Message] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
     

--- a/semantic_search.py
+++ b/semantic_search.py
@@ -1,14 +1,14 @@
 import pymongo
 import logging
 from config import settings
-from langchain_huggingface import HuggingFaceEmbeddings
 from pinecone import Pinecone
+from model_cache import get_embedding_model
 
 logger = logging.getLogger(__name__)
 
 def semantic_search(query: str, top_k: int = 5):
     logger.debug("Starting semantic search for query: %s", query)
-    embedding_model = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+    embedding_model = get_embedding_model()
     query_embedding = embedding_model.embed_query(query)
 
     pc = Pinecone(api_key=settings.pinecone_api_key)

--- a/vector_store.py
+++ b/vector_store.py
@@ -5,8 +5,8 @@ from typing import Any, List
 from config import settings
 from langchain.schema import Document, BaseRetriever
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain_huggingface import HuggingFaceEmbeddings
 from pinecone import Pinecone, ServerlessSpec
+from model_cache import get_embedding_model
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ def initialize_vector_store(docs):
     )
     split_docs = text_splitter.split_documents(docs)
     
-    embedding_model = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+    embedding_model = get_embedding_model()
     pc = Pinecone(api_key=settings.pinecone_api_key)
     indexes = pc.list_indexes().names()
     if settings.pinecone_index_name not in indexes:


### PR DESCRIPTION
## Summary
- reuse heavy NLP and LLM models via a new `model_cache` module
- use cached embeddings/LLM in retrieval, RAG, and patient profiling modules
- ensure MongoDB clients are properly closed and connections are created on demand
- fix mutable default list in the `Conversation` schema

## Testing
- `python -m py_compile model_cache.py vector_store.py semantic_search.py patient_profile.py llm_rag.py archiver.py data_loader.py schemas.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890d2fb9ccc8326a7444865a06d439a