### PR TITLE
feat: standardize advice prompt format

### DIFF
--- a/llm_rag.py
+++ b/llm_rag.py
@@ -2,6 +2,7 @@ import logging
 from langchain.schema import HumanMessage
 from semantic_search import semantic_search
 from model_cache import get_chat_groq
+from prompt_templates import ADVICE_TEMPLATE
 
 logger = logging.getLogger(__name__)
 
@@ -11,14 +12,10 @@ def generate_advice(query: str):
     
     examples_text = ""
     for ex in examples:
-         examples_text += f"Patient: {ex.get('questionText', '')}\nTherapist: {ex.get('answerText', '')}\n\n"
+        examples_text += f"Patient: {ex.get('questionText', '')}\nTherapist: {ex.get('answerText', '')}\n\n"
 
-    prompt = f"""You are a mental health counselor. Based on the following examples, suggest advice:
-Examples:
-{examples_text}
-New Query: {query}
-Advice:"""
+    prompt = ADVICE_TEMPLATE.format(examples_text=examples_text, query=query)
     llm = get_chat_groq()
     response = llm.invoke([HumanMessage(content=prompt)])
     logger.debug("Advice generated: %s", response)
-    return response
+    return response.content if hasattr(response, "content") else str(response)

--- a/prompt_templates.py
+++ b/prompt_templates.py
@@ -1,0 +1,11 @@
+from langchain.prompts import ChatPromptTemplate
+
+ADVICE_TEMPLATE = ChatPromptTemplate.from_template(
+    "You are a mental health counselor. Based on the following examples, suggest advice.\n"
+    "Examples:\n{examples_text}\n"
+    "New Query: {query}\n\n"
+    "Respond using the following structure:\n"
+    "Advice: <clear recommendation>\n"
+    "Rationale: <brief justification>\n"
+    "Suggested Actions: <numbered steps>\n"
+)


### PR DESCRIPTION
## Summary
- add ADVICE_TEMPLATE using ChatPromptTemplate for structured advice response
- utilize template in `generate_advice` and return raw content string

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f8b16258832680ec0bdd1068b993