### PR TITLE
Add patient profile model with list fields

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -18,3 +18,9 @@ class Conversation(BaseModel):
     def add_message(self, message: Message):
         self.messages.append(message)
         self.updated_at = datetime.now()
+
+
+class PatientProfile(BaseModel):
+    patient_id: str
+    medical_history: List[str] = Field(default_factory=list)
+    therapy_goals: List[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- add `PatientProfile` schema with `medical_history` and `therapy_goals` lists
- load and normalize patient profiles, converting `medical_history` and `therapy_goals` to arrays and updating MongoDB
- incorporate patient profile lists in Pinecone update

## Testing
- `python -m py_compile schemas.py patient_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_6891787437a88326ad445642b0ec9a8b