### PR TITLE
Add session logging and patient validation

### DIFF
--- a/archiver.py
+++ b/archiver.py
@@ -1,14 +1,25 @@
 import pymongo
 import logging
+from typing import Optional
 from config import settings
-from schemas import Conversation
+from schemas import Conversation, SessionLog
 
 logger = logging.getLogger(__name__)
+
+def _patient_profile_exists(db, patient_id: str) -> bool:
+    """Check if a patient profile exists in the database."""
+
+    return db["PatientProfiles"].count_documents(
+        {"patient_id": patient_id}, limit=1
+    ) > 0
+
 
 def archive_conversation(conversation: Conversation):
     conv_dict = conversation.dict()
     with pymongo.MongoClient(settings.safe_mongo_uri) as client:
         db = client.get_database("MentalHealthDB")
+        if not _patient_profile_exists(db, conversation.patient_id):
+            raise ValueError(f"Patient profile {conversation.patient_id} does not exist")
         conversations_collection = db['PatientConvo']
         conversations_collection.replace_one(
             {"session_id": conversation.session_id},
@@ -16,3 +27,36 @@ def archive_conversation(conversation: Conversation):
             upsert=True
         )
     logger.info("Conversation %s archived successfully.", conversation.session_id)
+
+
+def archive_session(log: SessionLog):
+    """Archive analytical results for a counseling session."""
+
+    log_dict = log.dict()
+    with pymongo.MongoClient(settings.safe_mongo_uri) as client:
+        db = client.get_database("MentalHealthDB")
+        if not _patient_profile_exists(db, log.patient_id):
+            raise ValueError(f"Patient profile {log.patient_id} does not exist")
+        sessions_collection = db["sessions"]
+        sessions_collection.replace_one(
+            {"session_id": log.session_id},
+            log_dict,
+            upsert=True,
+        )
+    logger.info("Session %s archived successfully.", log.session_id)
+
+
+def load_session(session_id: str) -> Optional[SessionLog]:
+    """Load a session log from the database with patient validation."""
+
+    with pymongo.MongoClient(settings.safe_mongo_uri) as client:
+        db = client.get_database("MentalHealthDB")
+        sessions_collection = db["sessions"]
+        doc = sessions_collection.find_one({"session_id": session_id})
+        if not doc:
+            return None
+        if not _patient_profile_exists(db, doc.get("patient_id", "")):
+            raise ValueError(
+                f"Patient profile {doc.get('patient_id')} does not exist"
+            )
+        return SessionLog(**doc)

--- a/schemas.py
+++ b/schemas.py
@@ -18,3 +18,15 @@ class Conversation(BaseModel):
     def add_message(self, message: Message):
         self.messages.append(message)
         self.updated_at = datetime.now()
+
+
+class SessionLog(BaseModel):
+    """Metadata and analytical results for a counseling session."""
+
+    session_id: str
+    patient_id: str
+    detected_topics: List[str] = Field(default_factory=list)
+    recommendations: List[str] = Field(default_factory=list)
+    risk_flags: List[str] = Field(default_factory=list)
+    sentiment_score: float = 0.0
+    created_at: datetime = Field(default_factory=datetime.now)


### PR DESCRIPTION
## Summary
- add `SessionLog` model with topic, recommendation, risk flag lists and sentiment score
- archive session logs with patient-profile validation and implement loader
- validate patient profile when saving conversations

## Testing
- `python -m py_compile schemas.py archiver.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891787f93a08326b0d6713b37a84fae