### PR TITLE
feat: enrich counselor guidance with analytics

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,13 +11,14 @@ def unified_chat_mode():
     print("Unified Guidance Chat Mode (multi-turn conversation):")
     print("Type 'exit' to end the session.\n")
     conversation_history = ""
+    patient_profile = {}
     while True:
         user_input = input("Counselor: ").strip()
         if user_input.lower() == 'exit':
             logger.info("Exiting chat mode")
             break
         
-        guidance = generate_counselor_guidance(user_input, conversation_history)
+        guidance = generate_counselor_guidance(user_input, patient_profile, conversation_history)
         
         print("\n--- Generated Advice ---")
         print(guidance.get("generated_advice", "No advice generated."))
@@ -26,6 +27,11 @@ def unified_chat_mode():
         topic = guidance.get("predicted_topic", "N/A")
         score = guidance.get("topic_confidence", "N/A")
         print(f"{topic} (Confidence: {score})")
+
+        print("\n--- Sentiment ---")
+        sentiment = guidance.get("sentiment", "N/A")
+        s_score = guidance.get("sentiment_score", "N/A")
+        print(f"{sentiment} (Score: {s_score})")
         
         print("\n--- Historical Examples ---")
         examples = guidance.get("historical_examples", [])

--- a/main_fastapi.py
+++ b/main_fastapi.py
@@ -18,13 +18,17 @@ app = FastAPI(
 # Pydantic models for request and response
 class GuidanceRequest(BaseModel):
     user_input: str
+    patient_profile: Optional[Dict[str, Any]] = None
     conversation_history: Optional[str] = ""
 
 class GuidanceResponse(BaseModel):
     generated_advice: str
     predicted_topic: str
     topic_confidence: float
+    sentiment: str
+    sentiment_score: float
     historical_examples: List[Dict[str, Any]]
+    patient_profile: Dict[str, Any]
 
 
 @app.get("/")
@@ -35,12 +39,19 @@ def root():
 @app.post("/guidance", response_model=GuidanceResponse)
 def get_guidance(request: GuidanceRequest):
     try:
-        guidance = generate_counselor_guidance(request.user_input, request.conversation_history)
+        guidance = generate_counselor_guidance(
+            request.user_input,
+            request.patient_profile,
+            request.conversation_history,
+        )
         return GuidanceResponse(
             generated_advice=guidance.get("generated_advice", ""),
             predicted_topic=guidance.get("predicted_topic", ""),
             topic_confidence=guidance.get("topic_confidence", 0.0),
-            historical_examples=guidance.get("historical_examples", [])
+            sentiment=guidance.get("sentiment", ""),
+            sentiment_score=guidance.get("sentiment_score", 0.0),
+            historical_examples=guidance.get("historical_examples", []),
+            patient_profile=guidance.get("patient_profile", {}),
         )
     except Exception as e:
         logger.exception("Error generating guidance")

--- a/unified_guidance.py
+++ b/unified_guidance.py
@@ -1,21 +1,57 @@
 import logging
 from semantic_search import semantic_search
 from topic_classifier import predict_topic, load_topic_classifier
+from patient_ml import simple_sentiment_analysis
 from llm_rag import generate_advice
 
 logger = logging.getLogger(__name__)
 
-def generate_counselor_guidance(user_input: str, conversation_history: str = ""):
+def generate_counselor_guidance(
+    user_input: str,
+    patient_profile: dict | None = None,
+    conversation_history: str = "",
+):
+    """Generate guidance for counselors based on the latest patient message.
+
+    Args:
+        user_input: Latest message from the patient.
+        patient_profile: Attributes describing the patient.
+        conversation_history: Prior conversation transcript.
+
+    Returns:
+        Dictionary with generated advice and analytics for the counselor.
+    """
+
     logger.debug("Generating counselor guidance. User input: %s", user_input)
-    combined_input = conversation_history + "\n" + user_input if conversation_history else user_input
-    examples = semantic_search(user_input, top_k=3)
-    logger.debug("Retrieved %d historical examples.", len(examples))
-    
+
+    # Topic classification and sentiment analysis for the latest message
     classifier = load_topic_classifier()
     predicted_topic, topic_score = predict_topic(user_input, classifier)
     logger.debug("Predicted topic: %s with score: %s", predicted_topic, topic_score)
-    
-    advice_obj = generate_advice(combined_input)
+
+    sentiment_score = simple_sentiment_analysis(user_input)
+    sentiment = (
+        "Positive" if sentiment_score > 0 else "Negative" if sentiment_score < 0 else "Neutral"
+    )
+    logger.debug("Sentiment score: %s (%s)", sentiment_score, sentiment)
+
+    # Prepare context for advice generation incorporating profile and analytics
+    profile_text = "".join(
+        f"{k}: {v}\n" for k, v in patient_profile.items()
+    ) if patient_profile else ""
+
+    analysis_context = (
+        f"Patient Profile:\n{profile_text}\n"
+        f"Conversation History:\n{conversation_history}\n"
+        f"Latest Message: {user_input}\n"
+        f"Predicted Topic: {predicted_topic} (Confidence: {topic_score})\n"
+        f"Sentiment: {sentiment} (Score: {sentiment_score})"
+    )
+
+    examples = semantic_search(user_input, top_k=3)
+    logger.debug("Retrieved %d historical examples.", len(examples))
+
+    advice_obj = generate_advice(analysis_context)
     
     if isinstance(advice_obj, list):
         advice_text = advice_obj[0].content if hasattr(advice_obj[0], "content") else str(advice_obj[0])
@@ -30,6 +66,9 @@ def generate_counselor_guidance(user_input: str, conversation_history: str = "")
         "generated_advice": advice_text,
         "predicted_topic": predicted_topic,
         "topic_confidence": topic_score,
-        "historical_examples": examples
+        "sentiment": sentiment,
+        "sentiment_score": sentiment_score,
+        "historical_examples": examples,
+        "patient_profile": patient_profile or {},
     }
     return guidance


### PR DESCRIPTION
## Summary
- expand counselor guidance to ingest patient profile details and analyze per-message topic and sentiment
- feed profile and analysis into LLM advice generation and return analytics
- expose recommendations and analytics in CLI, API, and Streamlit chat UI

## Testing
- `python -m py_compile unified_guidance.py main.py main_fastapi.py app_chat.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891788284f08326bb1aed9c5991ef60