### PR TITLE
Add patient ID capture and profile creation

### DIFF
--- a/app_chat.py
+++ b/app_chat.py
@@ -9,6 +9,7 @@ from schemas import Conversation, Message
 from topic_classifier import predict_topic, load_topic_classifier
 from patient_ml import simple_sentiment_analysis
 from llm_rag import generate_advice
+from patient_profile import get_patient_profile, create_patient_profile
 
 # Ensure an event loop is available
 try:
@@ -73,7 +74,19 @@ def landing_page():
         </div>
         """, unsafe_allow_html=True)
 
+    patient_id = st.text_input("Patient ID", key="patient_id_input")
+
     if st.button("Get Started"):
+        if not patient_id.strip():
+            st.error("Please enter a patient ID before starting.")
+            return
+
+        profile = get_patient_profile(patient_id)
+        if profile is None:
+            profile = create_patient_profile(patient_id)
+
+        st.session_state.patient_profile = profile.dict()
+        st.session_state.conversation_model.patient_id = patient_id
         st.session_state.page = "chat"
         st.rerun()
 

--- a/patient_profile.py
+++ b/patient_profile.py
@@ -52,6 +52,19 @@ def get_patient_profile(patient_id: str) -> PatientProfile | None:
 
     return PatientProfile(**data)
 
+
+def create_patient_profile(patient_id: str, medical_history=None, therapy_goals=None) -> PatientProfile:
+    client = pymongo.MongoClient(settings.safe_mongo_uri)
+    db = client.get_database("MentalHealthDB")
+    collection = db["patients"]
+    profile_data = {
+        "patient_id": patient_id,
+        "medical_history": medical_history or [],
+        "therapy_goals": therapy_goals or [],
+    }
+    collection.insert_one(profile_data)
+    return PatientProfile(**profile_data)
+
 def update_patient_profile(patient_id: str):
     conv = get_patient_conversation(patient_id)
     profile = get_patient_profile(patient_id)


### PR DESCRIPTION
## Summary
- Add patient ID input on landing page and load or create profiles on confirmation.
- Implement profile creation utility to insert default patient documents.

## Testing
- `python -m py_compile app_chat.py patient_profile.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689189c2959883268cf4dd80cee82002