### PR TITLE
Tier 2 & 3: transformer sentiment, patient profiles, and DB/RAG reliability fixes

### DIFF
--- a/app_chat.py
+++ b/app_chat.py
@@ -7,9 +7,9 @@ from unified_guidance import generate_counselor_guidance
 from archiver import archive_conversation, archive_session
 from schemas import Conversation, Message, SessionLog
 from topic_classifier import predict_topic, load_topic_classifier
-from patient_ml import simple_sentiment_analysis
+from patient_ml import analyze_sentiment
 from llm_rag import generate_advice
-from patient_profile import get_patient_profile, create_patient_profile
+from patient_profile import get_patient_profile, create_patient_profile, update_patient_fields
 from safety import SafetyChecker
 
 # Ensure an event loop is available
@@ -59,6 +59,10 @@ if "session_risk_flags" not in st.session_state:
 if "session_topics" not in st.session_state:
     st.session_state.session_topics = []
 
+def _parse_lines(text):
+    """Split a textarea value into a clean list of non-empty, stripped lines."""
+    return [line.strip() for line in (text or "").splitlines() if line.strip()]
+
 # Landing Page
 def landing_page():
     st.markdown("""
@@ -83,15 +87,43 @@ def landing_page():
         """, unsafe_allow_html=True)
 
     patient_id = st.text_input("Patient ID", key="patient_id_input")
+    medical_history_input = st.text_area(
+        "Medical history (optional, one item per line)", key="medical_history_input"
+    )
+    therapy_goals_input = st.text_area(
+        "Therapy goals (optional, one item per line)", key="therapy_goals_input"
+    )
 
     if st.button("Get Started"):
-        if not patient_id.strip():
+        patient_id = patient_id.strip()
+        if not patient_id:
             st.error("Please enter a patient ID before starting.")
             return
 
-        profile = get_patient_profile(patient_id)
-        if profile is None:
-            profile = create_patient_profile(patient_id)
+        medical_history = _parse_lines(medical_history_input)
+        therapy_goals = _parse_lines(therapy_goals_input)
+
+        try:
+            profile = get_patient_profile(patient_id)
+            if profile is None:
+                profile = create_patient_profile(
+                    patient_id,
+                    medical_history=medical_history,
+                    therapy_goals=therapy_goals,
+                )
+            elif (medical_history and not profile.medical_history) or (
+                therapy_goals and not profile.therapy_goals
+            ):
+                # Enrich a previously-empty profile with the entered details.
+                profile = update_patient_fields(
+                    patient_id,
+                    medical_history=medical_history or profile.medical_history,
+                    therapy_goals=therapy_goals or profile.therapy_goals,
+                )
+        except Exception:
+            logger.exception("Failed to load or create patient profile")
+            st.error("Could not load the patient profile. Please try again later.")
+            return
 
         st.session_state.patient_profile = profile.dict()
         st.session_state.conversation_model.patient_id = patient_id
@@ -101,6 +133,21 @@ def landing_page():
 # Chat Page
 def chat_page():
     st.title("🧠 Mental Health Counselor Guidance")
+
+    # Show the loaded patient profile so the personalization context is visible.
+    profile = st.session_state.get("patient_profile") or {}
+    medical_history = profile.get("medical_history") or []
+    therapy_goals = profile.get("therapy_goals") or []
+    if medical_history or therapy_goals:
+        with st.expander("Patient profile", expanded=False):
+            if medical_history:
+                st.markdown("**Medical history**")
+                for item in medical_history:
+                    st.markdown(f"- {item}")
+            if therapy_goals:
+                st.markdown("**Therapy goals**")
+                for item in therapy_goals:
+                    st.markdown(f"- {item}")
 
     # Display messages freshly each time using Streamlit's native chat components
     for msg in st.session_state.conversation:
@@ -223,8 +270,7 @@ def chat_page():
                 predicted_topic, topic_confidence = predict_topic(conversation_text, classifier)
                 
                 # Evaluate overall sentiment
-                sentiment_score = simple_sentiment_analysis(conversation_text)
-                sentiment = "Positive" if sentiment_score > 0 else "Negative" if sentiment_score < 0 else "Neutral"
+                sentiment, sentiment_score = analyze_sentiment(conversation_text)
                 
                 # Prepare a structured prompt for generating actionable recommendations
                 prompt = (

--- a/archiver.py
+++ b/archiver.py
@@ -1,7 +1,6 @@
-import pymongo
 import logging
 from typing import Optional
-from config import settings
+from db import get_db
 from schemas import Conversation, SessionLog
 
 logger = logging.getLogger(__name__)
@@ -16,16 +15,15 @@ def _patient_profile_exists(db, patient_id: str) -> bool:
 
 def archive_conversation(conversation: Conversation):
     conv_dict = conversation.dict()
-    with pymongo.MongoClient(settings.safe_mongo_uri) as client:
-        db = client.get_database("MentalHealthDB")
-        if not _patient_profile_exists(db, conversation.patient_id):
-            raise ValueError(f"Patient profile {conversation.patient_id} does not exist")
-        conversations_collection = db['PatientConvo']
-        conversations_collection.replace_one(
-            {"session_id": conversation.session_id},
-            conv_dict,
-            upsert=True
-        )
+    db = get_db()
+    if not _patient_profile_exists(db, conversation.patient_id):
+        raise ValueError(f"Patient profile {conversation.patient_id} does not exist")
+    conversations_collection = db['PatientConvo']
+    conversations_collection.replace_one(
+        {"session_id": conversation.session_id},
+        conv_dict,
+        upsert=True
+    )
     logger.info("Conversation %s archived successfully.", conversation.session_id)
 
 
@@ -33,30 +31,28 @@ def archive_session(log: SessionLog):
     """Archive analytical results for a counseling session."""
 
     log_dict = log.dict()
-    with pymongo.MongoClient(settings.safe_mongo_uri) as client:
-        db = client.get_database("MentalHealthDB")
-        if not _patient_profile_exists(db, log.patient_id):
-            raise ValueError(f"Patient profile {log.patient_id} does not exist")
-        sessions_collection = db["sessions"]
-        sessions_collection.replace_one(
-            {"session_id": log.session_id},
-            log_dict,
-            upsert=True,
-        )
+    db = get_db()
+    if not _patient_profile_exists(db, log.patient_id):
+        raise ValueError(f"Patient profile {log.patient_id} does not exist")
+    sessions_collection = db["sessions"]
+    sessions_collection.replace_one(
+        {"session_id": log.session_id},
+        log_dict,
+        upsert=True,
+    )
     logger.info("Session %s archived successfully.", log.session_id)
 
 
 def load_session(session_id: str) -> Optional[SessionLog]:
     """Load a session log from the database with patient validation."""
 
-    with pymongo.MongoClient(settings.safe_mongo_uri) as client:
-        db = client.get_database("MentalHealthDB")
-        sessions_collection = db["sessions"]
-        doc = sessions_collection.find_one({"session_id": session_id})
-        if not doc:
-            return None
-        if not _patient_profile_exists(db, doc.get("patient_id", "")):
-            raise ValueError(
-                f"Patient profile {doc.get('patient_id')} does not exist"
-            )
-        return SessionLog(**doc)
+    db = get_db()
+    sessions_collection = db["sessions"]
+    doc = sessions_collection.find_one({"session_id": session_id})
+    if not doc:
+        return None
+    if not _patient_profile_exists(db, doc.get("patient_id", "")):
+        raise ValueError(
+            f"Patient profile {doc.get('patient_id')} does not exist"
+        )
+    return SessionLog(**doc)

--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
     @property
     def safe_mongo_uri(self):
         import re
-        match = re.match(r"(mongodb://)(.*):(.*)@(.*)", self.mongo_uri)
+        match = re.match(r"(mongodb(?:\+srv)?://)(.*):(.*)@(.*)", self.mongo_uri)
         if match:
             prefix, user, pwd, rest = match.groups()
             user_encoded = quote_plus(user)

--- a/db.py
+++ b/db.py
@@ -1,0 +1,22 @@
+from functools import lru_cache
+import pymongo
+from config import settings
+
+DB_NAME = "MentalHealthDB"
+
+
+@lru_cache(maxsize=1)
+def get_mongo_client():
+    """Return a process-wide cached MongoClient.
+
+    pymongo manages an internal connection pool, so a single client should be
+    created once and reused across calls. Creating a new client per operation
+    (the previous pattern) spins up a fresh pool each time and leaks
+    connections when the client is never closed.
+    """
+    return pymongo.MongoClient(settings.safe_mongo_uri)
+
+
+def get_db(name: str = DB_NAME):
+    """Return the application database from the shared client."""
+    return get_mongo_client().get_database(name)

--- a/llm_rag.py
+++ b/llm_rag.py
@@ -6,10 +6,11 @@ from prompt_templates import ADVICE_TEMPLATE
 
 logger = logging.getLogger(__name__)
 
-def generate_advice(query: str):
+def generate_advice(query: str, examples=None):
     logger.debug("Generating advice for query: %s", query)
-    examples = semantic_search(query, top_k=3)
-    
+    if examples is None:
+        examples = semantic_search(query, top_k=3)
+
     examples_text = ""
     for ex in examples:
         examples_text += f"Patient: {ex.get('questionText', '')}\nTherapist: {ex.get('answerText', '')}\n\n"

--- a/patient_ml.py
+++ b/patient_ml.py
@@ -1,14 +1,58 @@
 import logging
+from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
+# Below this model confidence a binary prediction is treated as Neutral.
+NEUTRAL_THRESHOLD = 0.65
+
+
 def simple_sentiment_analysis(text):
+    """Lightweight word-count heuristic, used as a fallback when the
+    transformer sentiment model is unavailable."""
     positive_words = {"happy", "good", "great", "positive", "joy", "love"}
     negative_words = {"sad", "bad", "terrible", "negative", "hate", "depressed"}
     text_lower = text.lower()
     pos_count = sum(text_lower.count(word) for word in positive_words)
     neg_count = sum(text_lower.count(word) for word in negative_words)
     return pos_count - neg_count
+
+
+@lru_cache(maxsize=1)
+def load_sentiment_model():
+    """Return a cached transformers sentiment-analysis pipeline."""
+    from transformers import pipeline
+    model = pipeline("sentiment-analysis")
+    logger.debug("Sentiment model loaded.")
+    return model
+
+
+def analyze_sentiment(text: str):
+    """Classify the sentiment of ``text``.
+
+    Returns a ``(label, score)`` tuple where label is one of
+    ``"Positive"``/``"Negative"``/``"Neutral"`` and score is a signed
+    confidence in ``[-1.0, 1.0]``. Falls back to the word-count heuristic if
+    the transformer model cannot be loaded or run.
+    """
+    if not text or not text.strip():
+        return "Neutral", 0.0
+    try:
+        classifier = load_sentiment_model()
+        # Truncate to roughly the model's max sequence length to avoid errors.
+        result = classifier(text[:512])[0]
+        confidence = float(result["score"])
+        is_positive = "POS" in result["label"].upper()
+        signed = confidence if is_positive else -confidence
+        if confidence < NEUTRAL_THRESHOLD:
+            return "Neutral", signed
+        return ("Positive" if is_positive else "Negative"), signed
+    except Exception:
+        logger.exception("Sentiment model failed; using word-count fallback.")
+        score = simple_sentiment_analysis(text)
+        label = "Positive" if score > 0 else "Negative" if score < 0 else "Neutral"
+        return label, float(score)
+
 
 def train_patient_ml_model(patient_id: str):
     from patient_profile import get_patient_conversation
@@ -21,12 +65,6 @@ def train_patient_ml_model(patient_id: str):
         logger.warning("No patient messages found for sentiment analysis for patient %s", patient_id)
         return None
     full_text = " ".join(patient_texts)
-    score = simple_sentiment_analysis(full_text)
-    if score > 0:
-        sentiment = "positive"
-    elif score < 0:
-        sentiment = "negative"
-    else:
-        sentiment = "neutral"
-    logger.info("Patient %s sentiment: %s (score: %d)", patient_id, sentiment, score)
-    return sentiment
+    sentiment, score = analyze_sentiment(full_text)
+    logger.info("Patient %s sentiment: %s (score: %s)", patient_id, sentiment.lower(), score)
+    return sentiment.lower()

--- a/patient_profile.py
+++ b/patient_profile.py
@@ -62,6 +62,20 @@ def create_patient_profile(patient_id: str, medical_history=None, therapy_goals=
     collection.insert_one(profile_data)
     return PatientProfile(**profile_data)
 
+
+def update_patient_fields(patient_id: str, medical_history=None, therapy_goals=None) -> PatientProfile | None:
+    """Set medical_history / therapy_goals on an existing patient and return the
+    refreshed profile."""
+    db = get_db()
+    updates = {}
+    if medical_history is not None:
+        updates["medical_history"] = medical_history
+    if therapy_goals is not None:
+        updates["therapy_goals"] = therapy_goals
+    if updates:
+        db["patients"].update_one({"patient_id": patient_id}, {"$set": updates})
+    return get_patient_profile(patient_id)
+
 def update_patient_profile(patient_id: str):
     conv = get_patient_conversation(patient_id)
     profile = get_patient_profile(patient_id)

--- a/patient_profile.py
+++ b/patient_profile.py
@@ -1,8 +1,8 @@
 import time
 import json
-import pymongo
 import logging
 from config import settings
+from db import get_db
 from pinecone import Pinecone, ServerlessSpec
 from model_cache import get_embedding_model
 from schemas import PatientProfile
@@ -10,16 +10,14 @@ from schemas import PatientProfile
 logger = logging.getLogger(__name__)
 
 def get_patient_conversation(patient_id: str):
-    client = pymongo.MongoClient(settings.safe_mongo_uri)
-    db = client.get_database("MentalHealthDB")
+    db = get_db()
     collection = db['PatientConvo']
     conv = collection.find_one({"patient_id": patient_id})
     return conv
 
 
 def get_patient_profile(patient_id: str) -> PatientProfile | None:
-    client = pymongo.MongoClient(settings.safe_mongo_uri)
-    db = client.get_database("MentalHealthDB")
+    db = get_db()
     collection = db["patients"]
     data = collection.find_one({"patient_id": patient_id})
     if not data:
@@ -54,8 +52,7 @@ def get_patient_profile(patient_id: str) -> PatientProfile | None:
 
 
 def create_patient_profile(patient_id: str, medical_history=None, therapy_goals=None) -> PatientProfile:
-    client = pymongo.MongoClient(settings.safe_mongo_uri)
-    db = client.get_database("MentalHealthDB")
+    db = get_db()
     collection = db["patients"]
     profile_data = {
         "patient_id": patient_id,

--- a/semantic_search.py
+++ b/semantic_search.py
@@ -1,8 +1,8 @@
-import pymongo
 import logging
 from config import settings
 from pinecone import Pinecone
 from model_cache import get_embedding_model
+from db import get_db
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +31,7 @@ def semantic_search(query: str, top_k: int = 5):
          question_ids.append(qid)
     logger.debug("Extracted question IDs: %s", question_ids)
 
-    client = pymongo.MongoClient(settings.safe_mongo_uri)
-    db = client.get_database("MentalHealthDB")
+    db = get_db()
     collection = db["PatientConvo"]
     results = []
     for qid in question_ids:

--- a/unified_guidance.py
+++ b/unified_guidance.py
@@ -1,7 +1,7 @@
 import logging
 from semantic_search import semantic_search
 from topic_classifier import predict_topic, load_topic_classifier
-from patient_ml import simple_sentiment_analysis
+from patient_ml import analyze_sentiment
 from llm_rag import generate_advice
 from safety import SafetyChecker
 from urgency_detector import load_urgency_detector, detect_urgency
@@ -71,10 +71,7 @@ def generate_counselor_guidance(
         predicted_topic, topic_score = predict_topic(user_input, classifier)
         logger.debug("Predicted topic: %s with score: %s", predicted_topic, topic_score)
 
-        sentiment_score = simple_sentiment_analysis(user_input)
-        sentiment = (
-            "Positive" if sentiment_score > 0 else "Negative" if sentiment_score < 0 else "Neutral"
-        )
+        sentiment, sentiment_score = analyze_sentiment(user_input)
         logger.debug("Sentiment score: %s (%s)", sentiment_score, sentiment)
 
         # Prepare context for advice generation incorporating profile and analytics

--- a/unified_guidance.py
+++ b/unified_guidance.py
@@ -93,7 +93,9 @@ def generate_counselor_guidance(
         examples = semantic_search(user_input, top_k=3)
         logger.debug("Retrieved %d historical examples.", len(examples))
 
-        advice_obj = generate_advice(analysis_context)
+        # Reuse the examples already retrieved above instead of letting
+        # generate_advice run a second semantic search per message.
+        advice_obj = generate_advice(analysis_context, examples=examples)
 
         if isinstance(advice_obj, list):
             advice_text = advice_obj[0].content if hasattr(advice_obj[0], "content") else str(advice_obj[0])


### PR DESCRIPTION
## Summary
Follow-on improvements after the safety/urgency work merged in #14.

### Reliability (Tier 3)
- **Atlas URI encoding** — `safe_mongo_uri` now matches `mongodb+srv://`, so Atlas credentials with special characters are URL-encoded instead of silently failing to connect.
- **No duplicate semantic search** — `generate_advice` accepts pre-fetched examples; `generate_counselor_guidance` passes the ones it already retrieved, halving embedding + Pinecone round-trips per message.
- **Pooled MongoClient** — new `db.py` (`get_mongo_client`/`get_db`, cached) reused by the live-flow modules instead of creating a new client (and leaking connections) per call.

### Sentiment & profiles (Tier 2)
- **Transformer sentiment** — `analyze_sentiment` uses a cached transformers pipeline returning a (label, signed score), replacing the word-count heuristic on the live path, with a heuristic fallback if the model cannot load.
- **Patient profile capture** — landing page captures medical history and therapy goals; new profiles are created with them and previously-empty profiles are enriched; the chat page displays the loaded profile.
- Folded-in fixes: strip the patient ID before lookup/creation; error handling around profile load/create.

## Testing
Offline checks: files compile, SafetyChecker/sentiment behavior verified, Atlas regex verified. Full runtime requires `.env` + ML stack + MongoDB/Pinecone (manual Streamlit run).