### PR TITLE
Tier 4: app authentication, unit tests, and README accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ MentalHealthChatbot/
 ├── Dockerfile              # For container deployments (optional)
 ├── requirements.txt        # Dependencies (Streamlit, pymongo, torch, etc.)
 ├── config.py               # Application configuration
+├── db.py                   # Shared, cached MongoDB client
 ├── logging_config.py       # Centralized logging setup
 ├── schemas.py              # Pydantic models for data validation
 ├── patient_profile.py      # Manages patient profiles
@@ -61,8 +62,8 @@ MentalHealthChatbot/
 
 - Python 3.10 or later
 - MongoDB instance (local or hosted)
-- Pinecone API key and index configuration (if using Pinecone)
-- API keys for external LLM services (e.g., OpenAI, HuggingFace)
+- Pinecone API key and index configuration
+- A Groq API key for LLM inference (embeddings run locally via HuggingFace sentence-transformers, so no embedding API key is required)
 
 ### Installation Steps
 
@@ -88,7 +89,16 @@ MentalHealthChatbot/
 
 4. **Configure Environment Variables:**
 
-    Create a `.env` file in the project root with required variables (e.g., `MONGO_URI`, `PINECONE_API_KEY`, etc.).
+    Create a `.env` file in the project root with the following variables:
+
+    ```env
+    GROQ_API_KEY=your_groq_api_key
+    MONGO_URI=your_mongodb_uri          # mongodb:// or mongodb+srv:// (Atlas)
+    PINECONE_API_KEY=your_pinecone_api_key
+    PINECONE_INDEX_NAME=your_index_name
+    PINECONE_ENVIRONMENT=your_pinecone_region
+    APP_PASSWORD=optional_shared_password   # if set, gates the app behind a login
+    ```
 
 5. **Optional – Configure Streamlit File Watcher:**
 
@@ -121,9 +131,18 @@ This opens the chatbot interface in your browser at `http://localhost:8501`. Int
 - Sentiment analysis and scores  
 - Actionable recommendations for patient challenges  
 
-### Testing Backend Components
+### Running Tests
 
-Test individual modules (e.g., semantic search, ML model) by running their respective scripts or using unit tests if available.
+Unit tests live in `tests/` and run without any external services (no MongoDB, Pinecone, or model downloads required):
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
+### Authentication
+
+If `APP_PASSWORD` is set in the environment, the Streamlit app shows a login prompt and requires that password before use. If it is unset, the app runs without authentication (a warning is logged at startup).
 
 ## Deployment
 
@@ -145,7 +164,8 @@ For containerized deployment, use the provided Dockerfile to build a Docker imag
 - **Streamlit:** For building the interactive chatbot UI.
 - **Pymongo:** For interfacing with MongoDB.
 - **Torch:** Used with HuggingFace models for embeddings and NLP tasks.
-- **LangChain and Transformers:** For LLM-based guidance and classification tasks.
+- **LangChain with Groq (`langchain-groq`):** For LLM-based guidance generation (Groq-hosted Llama models).
+- **Transformers:** For zero-shot topic classification, sentiment analysis, and urgency/emotion detection.
 - **Pydantic:** For data validation and modeling.
 - Additional libraries: See `requirements.txt` for the complete list.
 

--- a/app_chat.py
+++ b/app_chat.py
@@ -11,6 +11,7 @@ from patient_ml import analyze_sentiment
 from llm_rag import generate_advice
 from patient_profile import get_patient_profile, create_patient_profile, update_patient_fields
 from safety import SafetyChecker
+from config import settings
 
 # Ensure an event loop is available
 try:
@@ -25,6 +26,32 @@ logger = logging.getLogger(__name__)
 
 # Stateless crisis screener for the guaranteed UI fallback (see chat_page).
 _safety_checker = SafetyChecker()
+
+if not settings.app_password:
+    logger.warning("APP_PASSWORD is not set — the app is running without authentication.")
+
+
+def check_authentication() -> bool:
+    """Gate the app behind a shared password when settings.app_password is set.
+
+    Returns True when access is allowed. When no password is configured access
+    is allowed (a warning is logged at startup); otherwise the user must enter
+    the matching password once per session.
+    """
+    if not settings.app_password:
+        return True
+    if st.session_state.get("authenticated"):
+        return True
+
+    st.title("🔒 Sign in")
+    password = st.text_input("Password", type="password", key="auth_password")
+    if st.button("Sign in"):
+        if password == settings.app_password:
+            st.session_state.authenticated = True
+            st.rerun()
+        else:
+            st.error("Incorrect password.")
+    return False
 
 # Page configuration
 st.set_page_config(
@@ -302,6 +329,9 @@ def chat_page():
                 st.error("An error occurred while generating the patient report. Please try again later.")
 
 # Main Navigation
+if not check_authentication():
+    st.stop()
+
 if st.session_state.page == "landing":
     landing_page()
 elif st.session_state.page == "chat":

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     pinecone_api_key: str
     pinecone_index_name: str
     pinecone_environment: str
+    app_password: str = ""  # optional shared password gating the Streamlit app
 
     class Config:
         env_file = ".env"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+import os
+
+# Provide dummy settings so modules that build `config.Settings()` at import
+# time can be imported during tests without a real .env file.
+os.environ.setdefault("GROQ_API_KEY", "test-key")
+os.environ.setdefault("MONGO_URI", "mongodb://user:pass@localhost:27017")
+os.environ.setdefault("PINECONE_API_KEY", "test-key")
+os.environ.setdefault("PINECONE_INDEX_NAME", "test-index")
+os.environ.setdefault("PINECONE_ENVIRONMENT", "us-east-1")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8,<9

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,22 @@
+from config import Settings
+
+
+def test_safe_mongo_uri_encodes_standard_scheme():
+    s = Settings(mongo_uri="mongodb://user:p@ssw0rd@host:27017")
+    out = s.safe_mongo_uri
+    assert out.startswith("mongodb://")
+    assert "p%40ssw0rd" in out  # '@' in the password is URL-encoded
+
+
+def test_safe_mongo_uri_handles_srv_scheme():
+    # Regression: the +srv (Atlas) scheme was previously not matched, so
+    # credentials were never encoded.
+    s = Settings(mongo_uri="mongodb+srv://admin:p@ss@cluster0.abc.mongodb.net")
+    out = s.safe_mongo_uri
+    assert out.startswith("mongodb+srv://")
+    assert "p%40ss" in out
+
+
+def test_safe_mongo_uri_passthrough_without_credentials():
+    s = Settings(mongo_uri="mongodb://localhost:27017")
+    assert s.safe_mongo_uri == "mongodb://localhost:27017"

--- a/tests/test_patient_ml.py
+++ b/tests/test_patient_ml.py
@@ -1,0 +1,28 @@
+import patient_ml
+from patient_ml import simple_sentiment_analysis, analyze_sentiment
+
+
+def test_simple_sentiment_counts():
+    assert simple_sentiment_analysis("I am happy and full of joy") > 0
+    assert simple_sentiment_analysis("I feel sad and depressed") < 0
+    assert simple_sentiment_analysis("the meeting is at noon") == 0
+
+
+def test_analyze_sentiment_empty_is_neutral():
+    assert analyze_sentiment("") == ("Neutral", 0.0)
+    assert analyze_sentiment("   ") == ("Neutral", 0.0)
+
+
+def test_analyze_sentiment_falls_back_when_model_unavailable(monkeypatch):
+    def boom():
+        raise RuntimeError("model unavailable")
+
+    monkeypatch.setattr(patient_ml, "load_sentiment_model", boom)
+
+    label, score = analyze_sentiment("I am so happy and full of joy")
+    assert label == "Positive"
+    assert score > 0
+
+    label, score = analyze_sentiment("I feel sad and depressed")
+    assert label == "Negative"
+    assert score < 0

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,43 @@
+from safety import SafetyChecker
+
+
+def test_suicide_risk_detected():
+    result = SafetyChecker().check_input("I want to kill myself")
+    assert result is not None
+    assert result["action"] == "CRITICAL"
+    assert result["flag_type"] == "suicide_risk"
+
+
+def test_violence_self_harm_fires():
+    # Regression: previously returned None because PROTOCOLS had no
+    # violence_risk entry, silently dropping self-harm alerts.
+    result = SafetyChecker().check_input("I want to harm myself")
+    assert result is not None
+    assert result["action"] == "CRITICAL"
+    assert result["flag_type"] == "violence_risk"
+
+
+def test_abuse_disclosure_detected():
+    result = SafetyChecker().check_input("there was abuse at home")
+    assert result is not None
+    assert result["action"] == "URGENT"
+    assert result["flag_type"] == "abuse_disclosure"
+
+
+def test_inflections_detected():
+    for text in [
+        "I feel suicidal",
+        "she was raped",
+        "I keep cutting myself",
+        "there is no reason to live",
+    ]:
+        assert SafetyChecker().check_input(text) is not None, text
+
+
+def test_benign_text_not_flagged():
+    for text in [
+        "I had a good day today",
+        "I love hiking and grapes",
+        "we discussed scheduling next week",
+    ]:
+        assert SafetyChecker().check_input(text) is None, text


### PR DESCRIPTION
## Summary
Hardening pass. **Stacks on #15** — base will auto-retarget to `main` once #15 merges, so this PR shows only the Tier 4 commits.

- **Authentication** — optional `APP_PASSWORD` setting. When set, the Streamlit app requires a password (once per session); when unset, it runs without auth and logs a startup warning, so existing deployments are not locked out.
- **Unit tests** — `tests/` covers SafetyChecker crisis detection (including the `violence_risk` regression and inflections), the sentiment heuristic + transformer fallback, and `safe_mongo_uri` encoding for both `mongodb://` and `mongodb+srv://`. `conftest.py` supplies dummy settings so `config` imports without a real `.env`; no external services needed. `requirements-dev.txt` adds pytest.
- **README** — corrected to reflect the Groq LLM stack (not OpenAI), documented the real `.env` variables and `APP_PASSWORD`, and added Running Tests / Authentication sections plus `db.py` in the structure.

## Testing
`pip install -r requirements-dev.txt && pytest`. All assertions validated manually in the sandbox (pytest/pip unavailable there); the suite needs no external services.