### PR TITLE
Investor demo sprint: live dashboard + self-serve demo mode

### DIFF
--- a/app_chat.py
+++ b/app_chat.py
@@ -91,6 +91,132 @@ def _parse_lines(text):
     """Split a textarea value into a clean list of non-empty, stripped lines."""
     return [line.strip() for line in (text or "").splitlines() if line.strip()]
 
+
+# Seeded demo patients so investors can try the tool without setup.
+DEMO_PERSONAS = {
+    "Alex — anxiety": {
+        "patient_id": "demo_alex",
+        "medical_history": ["generalized anxiety disorder", "chronic insomnia"],
+        "therapy_goals": ["improve sleep", "reduce daily anxiety"],
+    },
+    "Jordan — grief": {
+        "patient_id": "demo_jordan",
+        "medical_history": ["recent bereavement", "low mood"],
+        "therapy_goals": ["process grief", "re-engage with daily life"],
+    },
+    "Sam — work stress": {
+        "patient_id": "demo_sam",
+        "medical_history": ["burnout", "work-related stress"],
+        "therapy_goals": ["set boundaries", "manage workload stress"],
+    },
+}
+
+# One-click messages that walk a distress -> crisis -> recovery arc in a demo.
+SUGGESTED_PROMPTS = [
+    {"label": "Share distress", "text": "I've been really anxious lately and I can't sleep at all"},
+    {"label": "Express a crisis", "text": "Honestly, sometimes I feel like I want to end it all"},
+    {"label": "Show improvement", "text": "Talking this through actually helps — thank you"},
+]
+
+
+def start_demo(persona):
+    """Begin a self-serve demo with a seeded persona (in-memory, no DB writes)."""
+    st.session_state.demo_mode = True
+    st.session_state.patient_profile = {
+        "patient_id": persona["patient_id"],
+        "medical_history": list(persona["medical_history"]),
+        "therapy_goals": list(persona["therapy_goals"]),
+    }
+    st.session_state.conversation = []
+    st.session_state.conversation_model = Conversation(
+        session_id=str(uuid.uuid4()), patient_id=persona["patient_id"], messages=[]
+    )
+    st.session_state.session_risk_flags = []
+    st.session_state.session_topics = []
+    st.session_state.page = "chat"
+    st.rerun()
+
+
+def reset_session():
+    """Clear the session and return to the landing page."""
+    for key in (
+        "conversation", "conversation_model", "patient_profile",
+        "session_risk_flags", "session_topics", "demo_mode", "page",
+    ):
+        st.session_state.pop(key, None)
+    st.rerun()
+
+
+def handle_user_message(message):
+    """Run one patient message through the guidance pipeline and update state.
+
+    Shared by the chat input and the demo one-click prompts. Skips database
+    archiving in demo mode (the demo runs purely in-memory).
+    """
+    st.session_state.conversation.append({"role": "user", "content": message})
+    st.session_state.conversation_model.add_message(Message(content=message, is_user=True))
+
+    conversation_text = "\n".join(
+        f"{m['role'].capitalize()}: {m['content']}" for m in st.session_state.conversation
+    )
+
+    with st.spinner("Processing your message..."):
+        try:
+            guidance = generate_counselor_guidance(
+                message,
+                st.session_state.patient_profile,
+                conversation_text,
+            )
+            assistant_reply = guidance.get("generated_advice", "No advice available.")
+            analytics = {
+                "topic": guidance.get("predicted_topic"),
+                "topic_confidence": guidance.get("topic_confidence"),
+                "sentiment": guidance.get("sentiment"),
+                "sentiment_score": guidance.get("sentiment_score"),
+                "safety_protocol": guidance.get("safety_protocol"),
+                "urgency": guidance.get("urgency"),
+            }
+        except Exception:
+            logger.exception("Guidance generation error")
+            assistant_reply = "I'm sorry, something went wrong."
+            # Even on total failure, never drop the crisis screen for the latest message.
+            analytics = {"safety_protocol": _safety_checker.check_input(message)}
+
+    st.session_state.conversation.append({
+        "role": "assistant",
+        "content": assistant_reply,
+        "analysis": analytics,
+    })
+    st.session_state.conversation_model.add_message(
+        Message(content=assistant_reply, is_user=False, metadata=analytics)
+    )
+
+    # Roll up distinct risk flags + topics for the session.
+    protocol = analytics.get("safety_protocol")
+    flag_type = protocol.get("flag_type") if protocol else None
+    if flag_type and flag_type not in st.session_state.session_risk_flags:
+        st.session_state.session_risk_flags.append(flag_type)
+    topic = analytics.get("topic")
+    if topic and topic not in st.session_state.session_topics:
+        st.session_state.session_topics.append(topic)
+
+    # Persist to the database unless this is an in-memory demo session.
+    if not st.session_state.get("demo_mode"):
+        archive_conversation(st.session_state.conversation_model)
+        try:
+            archive_session(SessionLog(
+                session_id=st.session_state.conversation_model.session_id,
+                patient_id=st.session_state.conversation_model.patient_id,
+                detected_topics=st.session_state.session_topics,
+                risk_flags=st.session_state.session_risk_flags,
+                sentiment_score=float(analytics.get("sentiment_score") or 0.0),
+            ))
+        except Exception:
+            logger.exception("Failed to archive session log")
+
+    st.rerun()
+
+
 # Landing Page
 def landing_page():
     st.markdown("""
@@ -158,9 +284,23 @@ def landing_page():
         st.session_state.page = "chat"
         st.rerun()
 
+    st.divider()
+    st.markdown("#### Or try a live demo")
+    st.caption("Explore the tool with a sample patient — no patient ID or setup needed.")
+    demo_cols = st.columns(len(DEMO_PERSONAS))
+    for i, (name, persona) in enumerate(DEMO_PERSONAS.items()):
+        if demo_cols[i].button(name, key=f"demo_persona_{i}", use_container_width=True):
+            start_demo(persona)
+
 # Chat Page
 def chat_page():
     st.title("🧠 Mental Health Counselor Guidance")
+
+    ctrl_left, ctrl_right = st.columns([3, 1])
+    if st.session_state.get("demo_mode"):
+        ctrl_left.caption("Demo mode — sample patient, nothing is saved.")
+    if ctrl_right.button("New session", use_container_width=True):
+        reset_session()
 
     col_chat, col_dash = st.columns([1.4, 1], gap="large")
 
@@ -208,78 +348,18 @@ def chat_page():
             st.session_state.get("patient_profile") or {},
         )
 
-    # Chat input with spinner for each conversation message generation
+    # Demo: one-click messages that walk a distress -> crisis -> recovery arc.
+    if st.session_state.get("demo_mode"):
+        st.caption("Quick demo messages")
+        prompt_cols = st.columns(len(SUGGESTED_PROMPTS))
+        for i, prompt in enumerate(SUGGESTED_PROMPTS):
+            if prompt_cols[i].button(prompt["label"], key=f"suggested_{i}", use_container_width=True):
+                handle_user_message(prompt["text"])
+
+    # Chat input
     user_message = st.chat_input("Type your message here...")
     if user_message:
-        # Append user message
-        st.session_state.conversation.append({"role": "user", "content": user_message})
-        st.session_state.conversation_model.add_message(Message(content=user_message, is_user=True))
-
-        # Build conversation context
-        conversation_text = "\n".join(
-            f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.conversation
-        )
-
-        with st.spinner("Processing your message..."):
-            try:
-                guidance = generate_counselor_guidance(
-                    user_message,
-                    st.session_state.patient_profile,
-                    conversation_text,
-                )
-                assistant_reply = guidance.get("generated_advice", "No advice available.")
-                analytics = {
-                    "topic": guidance.get("predicted_topic"),
-                    "topic_confidence": guidance.get("topic_confidence"),
-                    "sentiment": guidance.get("sentiment"),
-                    "sentiment_score": guidance.get("sentiment_score"),
-                    "safety_protocol": guidance.get("safety_protocol"),
-                    "urgency": guidance.get("urgency"),
-                }
-            except Exception as e:
-                logger.exception("Guidance generation error")
-                assistant_reply = "I'm sorry, something went wrong."
-                # Even on total failure, never drop the crisis screen for the
-                # latest patient message — re-run the cheap regex directly.
-                analytics = {"safety_protocol": _safety_checker.check_input(user_message)}
-
-        # Append assistant's reply along with analytics
-        st.session_state.conversation.append({
-            "role": "assistant",
-            "content": assistant_reply,
-            "analysis": analytics,
-        })
-        st.session_state.conversation_model.add_message(
-            Message(content=assistant_reply, is_user=False, metadata=analytics)
-        )
-
-        # Archive conversation
-        archive_conversation(st.session_state.conversation_model)
-
-        # Roll up session-level analytics (distinct risk flags + topics) and
-        # persist a SessionLog so crisis events are captured even if the
-        # counselor never generates a report. Best-effort: never break chat.
-        protocol = analytics.get("safety_protocol")
-        flag_type = protocol.get("flag_type") if protocol else None
-        if flag_type and flag_type not in st.session_state.session_risk_flags:
-            st.session_state.session_risk_flags.append(flag_type)
-        topic = analytics.get("topic")
-        if topic and topic not in st.session_state.session_topics:
-            st.session_state.session_topics.append(topic)
-
-        try:
-            archive_session(SessionLog(
-                session_id=st.session_state.conversation_model.session_id,
-                patient_id=st.session_state.conversation_model.patient_id,
-                detected_topics=st.session_state.session_topics,
-                risk_flags=st.session_state.session_risk_flags,
-                sentiment_score=float(analytics.get("sentiment_score") or 0.0),
-            ))
-        except Exception:
-            logger.exception("Failed to archive session log")
-
-        # Refresh display to show new message
-        st.rerun()
+        handle_user_message(user_message)
 
     # Report generation section with spinner
     if st.button("Exit Conversation and Show Report", key="exit_button", help="Generate detailed patient report"):

--- a/app_chat.py
+++ b/app_chat.py
@@ -12,6 +12,7 @@ from llm_rag import generate_advice
 from patient_profile import get_patient_profile, create_patient_profile, update_patient_fields
 from safety import SafetyChecker
 from config import settings
+from dashboard import render_dashboard
 
 # Ensure an event loop is available
 try:
@@ -161,57 +162,51 @@ def landing_page():
 def chat_page():
     st.title("🧠 Mental Health Counselor Guidance")
 
-    # Show the loaded patient profile so the personalization context is visible.
-    profile = st.session_state.get("patient_profile") or {}
-    medical_history = profile.get("medical_history") or []
-    therapy_goals = profile.get("therapy_goals") or []
-    if medical_history or therapy_goals:
-        with st.expander("Patient profile", expanded=False):
-            if medical_history:
-                st.markdown("**Medical history**")
-                for item in medical_history:
-                    st.markdown(f"- {item}")
-            if therapy_goals:
-                st.markdown("**Therapy goals**")
-                for item in therapy_goals:
-                    st.markdown(f"- {item}")
+    col_chat, col_dash = st.columns([1.4, 1], gap="large")
 
-    # Display messages freshly each time using Streamlit's native chat components
-    for msg in st.session_state.conversation:
-        if msg["role"] == "user":
-            with st.chat_message("user"):
-                st.write(msg["content"])
-        else:
-            with st.chat_message("assistant"):
-                st.write(msg["content"])
-                analysis = msg.get("analysis")
-                if analysis:
-                    st.caption(
-                        f"Topic: {analysis.get('topic')} (Confidence: {analysis.get('topic_confidence', 0.0):.2f}) | "
-                        f"Sentiment: {analysis.get('sentiment')} ({analysis.get('sentiment_score')})"
-                    )
-
-                    safety_protocol = analysis.get("safety_protocol")
-                    if safety_protocol:
-                        action = safety_protocol.get("action", "URGENT")
-                        banner = (
-                            f"⚠️ Crisis indicator detected ({action}). "
-                            f"Suggested protocol: {safety_protocol.get('response', '')}"
+    with col_chat:
+        # Display messages freshly each time using Streamlit's native chat components
+        for msg in st.session_state.conversation:
+            if msg["role"] == "user":
+                with st.chat_message("user"):
+                    st.write(msg["content"])
+            else:
+                with st.chat_message("assistant"):
+                    st.write(msg["content"])
+                    analysis = msg.get("analysis")
+                    if analysis:
+                        st.caption(
+                            f"Topic: {analysis.get('topic')} (Confidence: {analysis.get('topic_confidence', 0.0):.2f}) | "
+                            f"Sentiment: {analysis.get('sentiment')} ({analysis.get('sentiment_score')})"
                         )
-                        if action == "CRITICAL":
-                            st.error(banner)
-                        else:
-                            st.warning(banner)
 
-                    # Only show the urgency banner when there is no crisis banner
-                    # already (the crisis banner takes priority and conveys urgency).
-                    urgency = analysis.get("urgency")
-                    if urgency and urgency.get("is_urgent") and not safety_protocol:
-                        score = urgency.get("score")
-                        score_text = f" ({score:.2f})" if isinstance(score, (int, float)) else ""
-                        st.warning(
-                            f"Elevated emotional urgency: {urgency.get('label')}{score_text}"
-                        )
+                        safety_protocol = analysis.get("safety_protocol")
+                        if safety_protocol:
+                            action = safety_protocol.get("action", "URGENT")
+                            banner = (
+                                f"⚠️ Crisis indicator detected ({action}). "
+                                f"Suggested protocol: {safety_protocol.get('response', '')}"
+                            )
+                            if action == "CRITICAL":
+                                st.error(banner)
+                            else:
+                                st.warning(banner)
+
+                        # Only show the urgency banner when there is no crisis banner
+                        # already (the crisis banner takes priority and conveys urgency).
+                        urgency = analysis.get("urgency")
+                        if urgency and urgency.get("is_urgent") and not safety_protocol:
+                            score = urgency.get("score")
+                            score_text = f" ({score:.2f})" if isinstance(score, (int, float)) else ""
+                            st.warning(
+                                f"Elevated emotional urgency: {urgency.get('label')}{score_text}"
+                            )
+
+    with col_dash:
+        render_dashboard(
+            st.session_state.conversation,
+            st.session_state.get("patient_profile") or {},
+        )
 
     # Chat input with spinner for each conversation message generation
     user_message = st.chat_input("Type your message here...")

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,91 @@
+import streamlit as st
+
+
+def _assistant_analyses(conversation):
+    """Per-message analytics dicts from the assistant turns of the conversation."""
+    return [m.get("analysis") or {} for m in (conversation or []) if m.get("role") == "assistant"]
+
+
+def render_dashboard(conversation, patient_profile):
+    """Render the live counselor dashboard from the conversation's analytics.
+
+    Reads only data already produced per message (sentiment, urgency/emotion,
+    topic, safety) — no model calls here.
+    """
+    st.subheader("Live session dashboard")
+    analyses = _assistant_analyses(conversation)
+
+    if not analyses:
+        st.caption("Emotional and risk metrics appear here as the conversation progresses.")
+        _render_profile(patient_profile)
+        return
+
+    latest = analyses[-1]
+    flagged = [a.get("safety_protocol") for a in analyses if a.get("safety_protocol")]
+
+    # Current risk status
+    sp = latest.get("safety_protocol")
+    if sp:
+        label = f"Risk: {sp.get('action', 'URGENT')} — {sp.get('flag_type')}"
+        (st.error if sp.get("action") == "CRITICAL" else st.warning)(label)
+    elif flagged:
+        st.warning(f"Risk: {len(flagged)} flag(s) earlier this session")
+    else:
+        st.success("Risk: none detected")
+
+    # Metric cards
+    c1, c2, c3 = st.columns(3)
+    score = latest.get("sentiment_score")
+    c1.metric("Sentiment", latest.get("sentiment") or "—",
+              f"{score:+.2f}" if isinstance(score, (int, float)) else None)
+    urgency = latest.get("urgency") or {}
+    emotion = urgency.get("label")
+    c2.metric("Emotion", emotion.title() if emotion else "—")
+    c3.metric("Topic", latest.get("topic") or "—")
+
+    bits = []
+    if isinstance(urgency.get("score"), (int, float)):
+        bits.append(f"emotion {urgency['score']:.0%}")
+    if isinstance(latest.get("topic_confidence"), (int, float)):
+        bits.append(f"topic {latest['topic_confidence']:.0%}")
+    if bits:
+        st.caption(" · ".join(bits) + " confidence")
+
+    # Emotional trajectory
+    scores = [a.get("sentiment_score") for a in analyses if isinstance(a.get("sentiment_score"), (int, float))]
+    if len(scores) >= 2:
+        st.caption("Emotional trajectory · sentiment per message")
+        st.line_chart(scores, height=160)
+
+    # Safety timeline
+    if flagged:
+        st.caption("Safety timeline")
+        for i, a in enumerate(analyses, start=1):
+            f = a.get("safety_protocol")
+            if f:
+                st.markdown(f"- Message {i}: **{f.get('action')}** — {f.get('flag_type')}")
+
+    # Topics detected this session
+    topics = []
+    for a in analyses:
+        topic = a.get("topic")
+        if topic and topic not in topics:
+            topics.append(topic)
+    if topics:
+        st.caption("Topics detected")
+        st.markdown(" ".join(f"`{t}`" for t in topics))
+
+    _render_profile(patient_profile)
+
+
+def _render_profile(patient_profile):
+    profile = patient_profile or {}
+    mh = profile.get("medical_history") or []
+    tg = profile.get("therapy_goals") or []
+    if not (mh or tg):
+        return
+    st.caption("Patient profile")
+    if mh:
+        st.markdown("**History:** " + ", ".join(mh))
+    if tg:
+        st.markdown("**Goals:** " + ", ".join(tg))


### PR DESCRIPTION
## Summary
Phase 1 of the investor demo sprint: a live analytics dashboard and a self-serve demo experience.

### Live session dashboard (`dashboard.py`)
A counselor "cockpit" rendered from the per-message analytics already in session state (no new model calls): current risk status, sentiment/emotion/topic metric cards, a sentiment-trajectory chart, a safety timeline, detected topics, and the patient profile. `chat_page` now uses a two-column layout (conversation left, dashboard right).

### Self-serve demo mode (`app_chat.py`)
- Landing-page "try a live demo" launcher with three seeded personas (Alex/anxiety, Jordan/grief, Sam/work-stress) — one click into a chat.
- Demo sessions run in-memory: no patient ID and no DB writes (archiving is skipped in demo mode), so anyone can try it with no setup or data risk.
- One-click suggested prompts that walk a distress -> crisis -> recovery arc and drive the live dashboard.
- "New session" reset and a demo-mode indicator.
- The shared message handler is extracted so the chat input and the demo prompt buttons run the same pipeline.

## Testing
Verified live in the browser: a persona click lands on the chat page with the dashboard, demo controls, prompts, and profile (no errors); the crisis prompt runs the real pipeline -> crisis banner + dashboard flips to Risk: CRITICAL + safety timeline logs `suicide_risk`. The standalone dashboard render was also confirmed against sample data.