### PR TITLE
Faster, explainable, polished UI: caching, streaming, why-panel, RAG fix

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -3,5 +3,8 @@ runOnSave = false
 
 [theme]
 base = "light"
-primaryColor = "#31333F"
+primaryColor = "#2E7D6B"
 backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F4F7F6"
+textColor = "#1F2933"
+font = "sans serif"

--- a/app_chat.py
+++ b/app_chat.py
@@ -3,16 +3,17 @@ import streamlit as st
 import logging
 import uuid
 from logging_config import setup_logging
-from unified_guidance import generate_counselor_guidance
+from unified_guidance import analyze_message
 from archiver import archive_conversation, archive_session
 from schemas import Conversation, Message, SessionLog
 from topic_classifier import predict_topic, load_topic_classifier
 from patient_ml import analyze_sentiment
-from llm_rag import generate_advice
+from llm_rag import generate_advice, stream_advice
 from patient_profile import get_patient_profile, create_patient_profile, update_patient_fields
 from safety import SafetyChecker
 from config import settings
 from dashboard import render_dashboard
+from explain import render_advice, render_why
 
 # Ensure an event loop is available
 try:
@@ -58,14 +59,18 @@ def check_authentication() -> bool:
 st.set_page_config(
     page_title="Mental Health Counselor Guidance",
     page_icon="🧠",
-    layout="centered",
+    layout="wide",
     initial_sidebar_state="collapsed"
 )
 
-# Hide default Streamlit menus and headers
+# Hide default Streamlit chrome and apply light layout polish.
 st.markdown("""
 <style>
 #MainMenu, footer, header {visibility: hidden;}
+.block-container {padding-top: 2.5rem; max-width: 1180px;}
+[data-testid="stChatMessage"] {padding: 0.2rem 0;}
+[data-testid="stMetric"] {background: var(--secondary-background-color, #F4F7F6);
+    border-radius: 10px; padding: 10px 14px;}
 </style>
 """, unsafe_allow_html=True)
 
@@ -160,35 +165,54 @@ def handle_user_message(message):
         f"{m['role'].capitalize()}: {m['content']}" for m in st.session_state.conversation
     )
 
-    with st.spinner("Processing your message..."):
-        try:
-            guidance = generate_counselor_guidance(
-                message,
-                st.session_state.patient_profile,
-                conversation_text,
+    assistant_reply = "I'm sorry, something went wrong."
+    analytics = {"safety_protocol": _safety_checker.check_input(message)}
+
+    try:
+        with st.status("Analyzing the patient message…", expanded=True) as status:
+            analysis = analyze_message(message, st.session_state.patient_profile, conversation_text)
+
+            sp = analysis.get("safety_protocol")
+            st.write(f"Safety: {sp['action'] + ' — ' + sp['flag_type'] if sp else 'no crisis indicators'}")
+            urgency = analysis.get("urgency") or {}
+            st.write(
+                f"Emotion: {urgency.get('label') or 'neutral'} · "
+                f"Topic: {analysis.get('predicted_topic') or 'n/a'} · "
+                f"Sentiment: {analysis.get('sentiment') or 'n/a'}"
             )
-            assistant_reply = guidance.get("generated_advice", "No advice available.")
-            analytics = {
-                "topic": guidance.get("predicted_topic"),
-                "topic_confidence": guidance.get("topic_confidence"),
-                "sentiment": guidance.get("sentiment"),
-                "sentiment_score": guidance.get("sentiment_score"),
-                "safety_protocol": guidance.get("safety_protocol"),
-                "urgency": guidance.get("urgency"),
-            }
-        except Exception:
-            logger.exception("Guidance generation error")
-            assistant_reply = "I'm sorry, something went wrong."
-            # Even on total failure, never drop the crisis screen for the latest message.
-            analytics = {"safety_protocol": _safety_checker.check_input(message)}
+            st.write(f"Retrieved {len(analysis.get('historical_examples') or [])} similar case(s).")
+
+            status.update(label="Generating guidance…")
+            assistant_reply = st.write_stream(
+                stream_advice(analysis.get("analysis_context", ""), analysis.get("historical_examples"))
+            ) or "No advice available."
+            status.update(label="Guidance ready", state="complete", expanded=False)
+
+        analytics = {
+            "topic": analysis.get("predicted_topic"),
+            "topic_confidence": analysis.get("topic_confidence"),
+            "sentiment": analysis.get("sentiment"),
+            "sentiment_score": analysis.get("sentiment_score"),
+            "safety_protocol": analysis.get("safety_protocol"),
+            "urgency": analysis.get("urgency"),
+            # Kept in session state only (not archived) for the "why this guidance" panel.
+            "historical_examples": analysis.get("historical_examples"),
+            "analysis_context": analysis.get("analysis_context"),
+        }
+    except Exception:
+        logger.exception("Guidance generation error")
+        analytics = {"safety_protocol": _safety_checker.check_input(message)}
 
     st.session_state.conversation.append({
         "role": "assistant",
         "content": assistant_reply,
         "analysis": analytics,
     })
+    # Archived metadata stays lean (no retrieved examples / raw context).
+    lean_metadata = {k: analytics.get(k) for k in
+                     ("topic", "topic_confidence", "sentiment", "sentiment_score", "safety_protocol", "urgency")}
     st.session_state.conversation_model.add_message(
-        Message(content=assistant_reply, is_user=False, metadata=analytics)
+        Message(content=assistant_reply, is_user=False, metadata=lean_metadata)
     )
 
     # Roll up distinct risk flags + topics for the session.
@@ -312,7 +336,7 @@ def chat_page():
                     st.write(msg["content"])
             else:
                 with st.chat_message("assistant"):
-                    st.write(msg["content"])
+                    render_advice(msg["content"])
                     analysis = msg.get("analysis")
                     if analysis:
                         st.caption(
@@ -341,6 +365,8 @@ def chat_page():
                             st.warning(
                                 f"Elevated emotional urgency: {urgency.get('label')}{score_text}"
                             )
+
+                        render_why(analysis)
 
     with col_dash:
         render_dashboard(
@@ -399,7 +425,7 @@ def chat_page():
                 st.markdown(f"**Predicted Topic:** {predicted_topic}  \n**Confidence:** {topic_confidence:.2f}")
                 st.markdown(f"**Overall Sentiment:** {sentiment}  \n**Sentiment Score:** {sentiment_score}")
                 st.markdown("### Recommendations")
-                st.write(recommendations)
+                st.markdown(recommendations)
                 
             except Exception as e:
                 logger.exception("Error generating report")

--- a/explain.py
+++ b/explain.py
@@ -1,0 +1,95 @@
+import re
+
+# Matches the section labels the advice prompt asks for, tolerating markdown
+# bold (**Advice:**) and leading whitespace.
+_LABEL_RE = re.compile(
+    r"^[ \t]*\**[ \t]*(Advice|Rationale|Suggested Actions|Actions)[ \t]*:[ \t]*\**[ \t]*",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def parse_advice(text):
+    """Split advice text into {advice, rationale, actions}.
+
+    Falls back to putting the whole text in 'advice' when the structure
+    (Advice / Rationale / Suggested Actions) is not present.
+    """
+    text = (text or "").strip()
+    if not text:
+        return {"advice": "", "rationale": "", "actions": ""}
+
+    matches = list(_LABEL_RE.finditer(text))
+    if not matches:
+        return {"advice": text, "rationale": "", "actions": ""}
+
+    out = {"advice": "", "rationale": "", "actions": ""}
+    for i, m in enumerate(matches):
+        key = m.group(1).lower()
+        key = "actions" if key in ("suggested actions", "actions") else key
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        out[key] = text[start:end].strip()
+
+    # Any text before the first labeled section is part of the advice.
+    lead = text[: matches[0].start()].strip()
+    if lead:
+        out["advice"] = (lead + ("\n" + out["advice"] if out["advice"] else "")).strip()
+    return out
+
+
+def render_advice(advice_text):
+    """Render advice as structured sections (Advice / Why / Suggested actions)."""
+    import streamlit as st
+    parts = parse_advice(advice_text)
+    if parts["advice"]:
+        st.markdown(parts["advice"])
+    if parts["rationale"]:
+        st.markdown(f"**Why:** {parts['rationale']}")
+    if parts["actions"]:
+        st.markdown("**Suggested actions**")
+        st.markdown(parts["actions"])
+    if not any(parts.values()):
+        st.markdown(advice_text or "")
+
+
+def render_why(analysis):
+    """Per-message 'Why this guidance' expander: the signals, retrieved cases,
+    and the exact context sent to the model."""
+    import streamlit as st
+    if not analysis:
+        return
+    with st.expander("Why this guidance"):
+        st.markdown("**Signals that informed this**")
+        rows = []
+        topic, tconf = analysis.get("topic"), analysis.get("topic_confidence")
+        if topic:
+            note = " · weak hint" if isinstance(tconf, (int, float)) and tconf < 0.4 else ""
+            conf = f" · {tconf:.0%} confidence{note}" if isinstance(tconf, (int, float)) else ""
+            rows.append(f"- Topic: `{topic}`{conf}")
+        sentiment, sscore = analysis.get("sentiment"), analysis.get("sentiment_score")
+        if sentiment:
+            score = f" ({sscore:+.2f})" if isinstance(sscore, (int, float)) else ""
+            rows.append(f"- Sentiment: {sentiment}{score}")
+        urgency = analysis.get("urgency") or {}
+        if urgency.get("label"):
+            score = f" ({urgency['score']:.0%})" if isinstance(urgency.get("score"), (int, float)) else ""
+            rows.append(f"- Emotion: {urgency['label']}{score}")
+        sp = analysis.get("safety_protocol")
+        if sp:
+            rows.append(f"- Safety: **{sp.get('action')}** — {sp.get('flag_type')}")
+        st.markdown("\n".join(rows) if rows else "_No signals recorded._")
+
+        examples = analysis.get("historical_examples") or []
+        st.markdown(f"**Similar past cases retrieved ({len(examples)})**")
+        if examples:
+            for ex in examples[:3]:
+                q = (ex.get("questionText") or "")[:200]
+                a = (ex.get("answerText") or "")[:200]
+                st.markdown(f"- *Patient:* {q}\n\n  *Therapist:* {a}")
+        else:
+            st.caption("None retrieved (semantic search returned no matches).")
+
+        context = analysis.get("analysis_context")
+        if context:
+            st.markdown("**Context sent to the model**")
+            st.code(context)

--- a/llm_rag.py
+++ b/llm_rag.py
@@ -6,17 +6,30 @@ from prompt_templates import ADVICE_TEMPLATE
 
 logger = logging.getLogger(__name__)
 
-def generate_advice(query: str, examples=None):
-    logger.debug("Generating advice for query: %s", query)
+
+def _build_prompt(query: str, examples=None) -> str:
     if examples is None:
         examples = semantic_search(query, top_k=3)
-
     examples_text = ""
     for ex in examples:
         examples_text += f"Patient: {ex.get('questionText', '')}\nTherapist: {ex.get('answerText', '')}\n\n"
+    return ADVICE_TEMPLATE.format(examples_text=examples_text, query=query)
 
-    prompt = ADVICE_TEMPLATE.format(examples_text=examples_text, query=query)
-    llm = get_chat_groq()
-    response = llm.invoke([HumanMessage(content=prompt)])
+
+def generate_advice(query: str, examples=None):
+    """Return the full advice text (blocking). Used by the API/CLI callers."""
+    logger.debug("Generating advice for query: %s", query)
+    prompt = _build_prompt(query, examples)
+    response = get_chat_groq().invoke([HumanMessage(content=prompt)])
     logger.debug("Advice generated: %s", response)
     return response.content if hasattr(response, "content") else str(response)
+
+
+def stream_advice(query: str, examples=None):
+    """Yield advice text chunks as the LLM produces them (for st.write_stream)."""
+    logger.debug("Streaming advice for query: %s", query)
+    prompt = _build_prompt(query, examples)
+    for chunk in get_chat_groq().stream([HumanMessage(content=prompt)]):
+        text = getattr(chunk, "content", None)
+        if text:
+            yield text

--- a/model_cache.py
+++ b/model_cache.py
@@ -16,3 +16,11 @@ def get_chat_groq():
         model_name="llama-3.3-70b-versatile",
         groq_api_key=settings.groq_api_key,
     )
+
+
+@lru_cache(maxsize=1)
+def get_pinecone_index():
+    """Return a cached Pinecone index handle (reused across messages)."""
+    from pinecone import Pinecone
+    pc = Pinecone(api_key=settings.pinecone_api_key)
+    return pc.Index(settings.pinecone_index_name)

--- a/semantic_search.py
+++ b/semantic_search.py
@@ -1,42 +1,51 @@
 import logging
-from config import settings
-from pinecone import Pinecone
-from model_cache import get_embedding_model
+from model_cache import get_embedding_model, get_pinecone_index
 from db import get_db
 
 logger = logging.getLogger(__name__)
 
+
+def _to_qid(value):
+    """Normalize a questionID. Pinecone stores it as a float (189.0); MongoDB
+    stores it as an int (189). Coerce both to int so they match."""
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return value
+
+
 def semantic_search(query: str, top_k: int = 5):
     logger.debug("Starting semantic search for query: %s", query)
-    embedding_model = get_embedding_model()
-    query_embedding = embedding_model.embed_query(query)
+    query_embedding = get_embedding_model().embed_query(query)
 
-    pc = Pinecone(api_key=settings.pinecone_api_key)
-    index = pc.Index(settings.pinecone_index_name)
-    response = index.query(
-         namespace="default",
-         vector=query_embedding,
-         top_k=top_k,
-         include_metadata=True
+    response = get_pinecone_index().query(
+        namespace="default",
+        vector=query_embedding,
+        top_k=top_k,
+        include_metadata=True,
     )
-    
     logger.debug("Pinecone response: %s", response)
-    
+
     question_ids = []
     for match in response["matches"]:
-         metadata = match.get("metadata", {})
-         qid = metadata.get("questionID", None)
-         if not qid:
-             qid = match.get("id")
-         question_ids.append(qid)
+        metadata = match.get("metadata") or {}
+        qid = metadata.get("questionID")
+        if qid is None:
+            qid = match.get("id")
+        qid = _to_qid(qid)
+        if qid is not None:
+            question_ids.append(qid)
     logger.debug("Extracted question IDs: %s", question_ids)
 
-    db = get_db()
-    collection = db["PatientConvo"]
-    results = []
+    # Pinecone gives float IDs, Mongo stores ints — query both forms, then
+    # re-order results to match the Pinecone ranking (single batched lookup).
+    variants = []
     for qid in question_ids:
-         doc = collection.find_one({"questionID": str(qid)})
-         if doc:
-              results.append(doc)
+        variants.append(qid)
+        if isinstance(qid, int):
+            variants.append(float(qid))
+    collection = get_db()["PatientConvo"]
+    docs = {_to_qid(d.get("questionID")): d for d in collection.find({"questionID": {"$in": variants}})}
+    results = [docs[qid] for qid in question_ids if qid in docs]
     logger.debug("Semantic search found %d documents", len(results))
     return results

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,44 @@
+import importlib.util
+
+import pytest
+
+from explain import parse_advice
+
+
+def test_parse_advice_structured():
+    text = "Advice: Do X.\nRationale: Because Y.\nSuggested Actions:\n1. A\n2. B"
+    p = parse_advice(text)
+    assert p["advice"] == "Do X."
+    assert p["rationale"] == "Because Y."
+    assert "1. A" in p["actions"] and "2. B" in p["actions"]
+
+
+def test_parse_advice_bold_labels():
+    text = "**Advice:** Do X.\n\n**Rationale:** Y\n\n**Suggested Actions:**\n1. A"
+    p = parse_advice(text)
+    assert p["advice"] == "Do X."
+    assert p["rationale"] == "Y"
+    assert "1. A" in p["actions"]
+
+
+def test_parse_advice_unstructured_fallback():
+    text = "Just plain advice with no sections."
+    p = parse_advice(text)
+    assert p["advice"] == text
+    assert p["rationale"] == "" and p["actions"] == ""
+
+
+def test_parse_advice_empty():
+    assert parse_advice("") == {"advice": "", "rationale": "", "actions": ""}
+    assert parse_advice(None) == {"advice": "", "rationale": "", "actions": ""}
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("transformers") is None,
+    reason="transformers not installed",
+)
+def test_topic_classifier_is_lru_cached():
+    # Regression: load_topic_classifier must be cached so the 1.6GB model is
+    # not reloaded per message. @lru_cache adds a cache_info attribute.
+    from topic_classifier import load_topic_classifier
+    assert hasattr(load_topic_classifier, "cache_info")

--- a/topic_classifier.py
+++ b/topic_classifier.py
@@ -1,4 +1,5 @@
 import logging
+from functools import lru_cache
 from transformers import pipeline
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ CANDIDATE_LABELS = [
     "workplace-relationships"
 ]
 
+@lru_cache(maxsize=1)
 def load_topic_classifier():
     classifier = pipeline("zero-shot-classification", model="facebook/bart-large-mnli")
     logger.debug("Topic classifier loaded.")

--- a/unified_guidance.py
+++ b/unified_guidance.py
@@ -11,26 +11,23 @@ logger = logging.getLogger(__name__)
 # Stateless crisis screener reused across calls.
 _safety_checker = SafetyChecker()
 
-def generate_counselor_guidance(
+
+def analyze_message(
     user_input: str,
     patient_profile: dict | None = None,
     conversation_history: str = "",
 ):
-    """Generate guidance for counselors based on the latest patient message.
+    """Run the non-LLM analysis for a message and assemble the LLM context.
 
-    Args:
-        user_input: Latest message from the patient.
-        patient_profile: Attributes describing the patient.
-        conversation_history: Prior conversation transcript.
-
-    Returns:
-        Dictionary with generated advice and analytics for the counselor.
+    Returns a dict with safety, urgency, topic, sentiment, the retrieved
+    ``historical_examples`` and the assembled ``analysis_context`` — but NOT the
+    generated advice, so the advice can be streamed separately. Resilient: a
+    downstream failure still returns the safety signal.
     """
-
-    logger.debug("Generating counselor guidance. User input: %s", user_input)
+    logger.debug("Analyzing message: %s", user_input)
 
     # Crisis-safety screen first — a cheap regex that must never be lost to a
-    # later (LLM/model) failure, so it is computed before any heavy work.
+    # later (model) failure, so it is computed before any heavy work.
     safety_protocol = _safety_checker.check_input(user_input)
     if safety_protocol:
         logger.warning(
@@ -40,8 +37,7 @@ def generate_counselor_guidance(
 
     # Seed with safe, format-friendly defaults so a downstream failure still
     # returns the safety signal and renders without errors.
-    guidance = {
-        "generated_advice": "I'm sorry, something went wrong.",
+    result = {
         "predicted_topic": None,
         "topic_confidence": 0.0,
         "sentiment": None,
@@ -50,6 +46,7 @@ def generate_counselor_guidance(
         "patient_profile": patient_profile or {},
         "safety_protocol": safety_protocol,
         "urgency": {"is_urgent": False, "label": None, "score": None},
+        "analysis_context": "",
     }
 
     # Best-effort emotional-urgency detection (heavy model; degrade gracefully).
@@ -57,7 +54,7 @@ def generate_counselor_guidance(
         is_urgent, urgency_label, urgency_score = detect_urgency(
             user_input, load_urgency_detector()
         )
-        guidance["urgency"] = {
+        result["urgency"] = {
             "is_urgent": is_urgent,
             "label": urgency_label,
             "score": urgency_score,
@@ -67,15 +64,14 @@ def generate_counselor_guidance(
 
     # A detected safety crisis is authoritative: always treat it as urgent, even
     # when the emotion model (which is not a crisis detector) did not flag it.
-    if safety_protocol and not guidance["urgency"]["is_urgent"]:
-        guidance["urgency"] = {
+    if safety_protocol and not result["urgency"]["is_urgent"]:
+        result["urgency"] = {
             "is_urgent": True,
-            "label": guidance["urgency"]["label"] or "crisis",
-            "score": guidance["urgency"]["score"] if guidance["urgency"]["score"] is not None else 1.0,
+            "label": result["urgency"]["label"] or "crisis",
+            "score": result["urgency"]["score"] if result["urgency"]["score"] is not None else 1.0,
         }
 
     try:
-        # Topic classification and sentiment analysis for the latest message
         classifier = load_topic_classifier()
         predicted_topic, topic_score = predict_topic(user_input, classifier)
         logger.debug("Predicted topic: %s with score: %s", predicted_topic, topic_score)
@@ -99,28 +95,52 @@ def generate_counselor_guidance(
         examples = semantic_search(user_input, top_k=3)
         logger.debug("Retrieved %d historical examples.", len(examples))
 
-        # Reuse the examples already retrieved above instead of letting
-        # generate_advice run a second semantic search per message.
-        advice_obj = generate_advice(analysis_context, examples=examples)
+        result.update({
+            "predicted_topic": predicted_topic,
+            "topic_confidence": topic_score,
+            "sentiment": sentiment,
+            "sentiment_score": sentiment_score,
+            "historical_examples": examples,
+            "analysis_context": analysis_context,
+        })
+    except Exception:
+        logger.exception("Message analysis failed; returning safety signal only.")
 
+    return result
+
+
+def generate_counselor_guidance(
+    user_input: str,
+    patient_profile: dict | None = None,
+    conversation_history: str = "",
+):
+    """Generate guidance for counselors based on the latest patient message.
+
+    Args:
+        user_input: Latest message from the patient.
+        patient_profile: Attributes describing the patient.
+        conversation_history: Prior conversation transcript.
+
+    Returns:
+        Dictionary with generated advice and analytics for the counselor.
+    """
+    logger.debug("Generating counselor guidance. User input: %s", user_input)
+
+    guidance = analyze_message(user_input, patient_profile, conversation_history)
+    guidance["generated_advice"] = "I'm sorry, something went wrong."
+
+    try:
+        advice_obj = generate_advice(
+            guidance["analysis_context"], examples=guidance["historical_examples"]
+        )
         if isinstance(advice_obj, list):
             advice_text = advice_obj[0].content if hasattr(advice_obj[0], "content") else str(advice_obj[0])
         elif hasattr(advice_obj, "content"):
             advice_text = advice_obj.content
         else:
             advice_text = str(advice_obj)
-
-        logger.debug("Generated advice: %s", advice_text)
-
-        guidance.update({
-            "generated_advice": advice_text,
-            "predicted_topic": predicted_topic,
-            "topic_confidence": topic_score,
-            "sentiment": sentiment,
-            "sentiment_score": sentiment_score,
-            "historical_examples": examples,
-        })
+        guidance["generated_advice"] = advice_text
     except Exception:
-        logger.exception("Counselor guidance generation failed; returning safety signal only.")
+        logger.exception("Advice generation failed.")
 
     return guidance


### PR DESCRIPTION
## Summary
Addresses three issues: the app was slow, felt like a black box, and the UI was basic. Five focused phases, all verified in the running app.

### Speed
- **Cache the topic classifier** — `load_topic_classifier` was the only model loader missing `@lru_cache`, so the ~1.6GB `bart-large-mnli` model was reloaded on every message (the dominant slowdown). Now loaded once per process (verified: it loads exactly once across messages).
- **Cache the Pinecone index** (`get_pinecone_index` in `model_cache`) instead of rebuilding the client per message; **batch** the Mongo lookups into one `$in` query.

### Perceived speed
- Responses **stream token-by-token** (`st.write_stream`) inside an `st.status` that shows the live pipeline stages (safety → emotion/topic/sentiment → retrieved N cases → generating). `stream_advice()` was added to `llm_rag`; `generate_advice()` (string) is kept for the FastAPI/CLI callers. `analyze_message()` was factored out of `generate_counselor_guidance` so analysis runs before the advice streams.

### Explainability (no longer a black box)
- New `explain.py`: `parse_advice()` splits the LLM output into **Advice / Rationale / Suggested Actions** (raw-text fallback); `render_advice()` renders the sections; `render_why()` is a per-message **"Why this guidance"** panel surfacing the driving signals, the **real retrieved similar cases**, and the exact context sent to the model.

### Fix empty RAG (P3)
- Root cause: Pinecone stores `questionID` as a float (`189.0`) but MongoDB stores it as an int (`189`), so the `str()` lookup never matched. Normalize IDs + query both forms. Verified live: semantic search now returns relevant cases.

### UI polish
- Calm clinical theme (teal primary, card surfaces), `layout="wide"` for the chat + dashboard cockpit, targeted CSS, markdown-rendered report.

## Testing
Verified live (demo mode): persona → message → streamed structured advice + "Why this guidance" panel + dashboard; the second message reused the cached model (topic classifier loaded once); crisis prompt → Risk CRITICAL + suicide_risk + banner; "Semantic search found 3 documents". New `tests/test_explain.py` covers `parse_advice` and a cache-presence check.