### PR TITLE
Doctor live-session assistant: two-channel transcript, decision-support panel, patient history

### DIFF
--- a/app_chat.py
+++ b/app_chat.py
@@ -8,12 +8,15 @@ from archiver import archive_conversation, archive_session
 from schemas import Conversation, Message, SessionLog
 from topic_classifier import predict_topic, load_topic_classifier
 from patient_ml import analyze_sentiment
-from llm_rag import generate_advice, stream_advice
-from patient_profile import get_patient_profile, create_patient_profile, update_patient_fields
+from llm_rag import generate_advice
+from patient_profile import (
+    get_patient_profile, create_patient_profile, update_patient_fields, get_patient_sessions,
+)
 from safety import SafetyChecker
 from config import settings
 from dashboard import render_dashboard
-from explain import render_advice, render_why
+from session_assistant import generate_session_suggestions, render_suggestions
+from patient_overview import render_patient_overview, build_patient_summary, build_history_summary
 
 # Ensure an event loop is available
 try:
@@ -26,7 +29,7 @@ except RuntimeError:
 setup_logging()
 logger = logging.getLogger(__name__)
 
-# Stateless crisis screener for the guaranteed UI fallback (see chat_page).
+# Stateless crisis screener for the guaranteed fallback.
 _safety_checker = SafetyChecker()
 
 if not settings.app_password:
@@ -34,12 +37,7 @@ if not settings.app_password:
 
 
 def check_authentication() -> bool:
-    """Gate the app behind a shared password when settings.app_password is set.
-
-    Returns True when access is allowed. When no password is configured access
-    is allowed (a warning is logged at startup); otherwise the user must enter
-    the matching password once per session.
-    """
+    """Gate the app behind a shared password when settings.app_password is set."""
     if not settings.app_password:
         return True
     if st.session_state.get("authenticated"):
@@ -57,8 +55,8 @@ def check_authentication() -> bool:
 
 # Page configuration
 st.set_page_config(
-    page_title="Mental Health Counselor Guidance",
-    page_icon="🧠",
+    page_title="Live Session Assistant",
+    page_icon="🩺",
     layout="wide",
     initial_sidebar_state="collapsed"
 )
@@ -67,7 +65,7 @@ st.set_page_config(
 st.markdown("""
 <style>
 #MainMenu, footer, header {visibility: hidden;}
-.block-container {padding-top: 2.5rem; max-width: 1180px;}
+.block-container {padding-top: 2.5rem; max-width: 1200px;}
 [data-testid="stChatMessage"] {padding: 0.2rem 0;}
 [data-testid="stMetric"] {background: var(--secondary-background-color, #F4F7F6);
     border-radius: 10px; padding: 10px 14px;}
@@ -81,9 +79,7 @@ if "conversation" not in st.session_state:
     st.session_state.conversation = []
 if "conversation_model" not in st.session_state:
     st.session_state.conversation_model = Conversation(
-        session_id=str(uuid.uuid4()),
-        patient_id="test_patient",
-        messages=[]
+        session_id=str(uuid.uuid4()), patient_id="test_patient", messages=[]
     )
 if "patient_profile" not in st.session_state:
     st.session_state.patient_profile = {}
@@ -91,13 +87,16 @@ if "session_risk_flags" not in st.session_state:
     st.session_state.session_risk_flags = []
 if "session_topics" not in st.session_state:
     st.session_state.session_topics = []
+if "session_suggestions" not in st.session_state:
+    st.session_state.session_suggestions = []
+
 
 def _parse_lines(text):
     """Split a textarea value into a clean list of non-empty, stripped lines."""
     return [line.strip() for line in (text or "").splitlines() if line.strip()]
 
 
-# Seeded demo patients so investors can try the tool without setup.
+# Seeded demo patients so the tool can be tried without setup.
 DEMO_PERSONAS = {
     "Alex — anxiety": {
         "patient_id": "demo_alex",
@@ -116,12 +115,32 @@ DEMO_PERSONAS = {
     },
 }
 
-# One-click messages that walk a distress -> crisis -> recovery arc in a demo.
+# One-click PATIENT turns that walk a distress -> crisis -> recovery arc in a demo.
 SUGGESTED_PROMPTS = [
     {"label": "Share distress", "text": "I've been really anxious lately and I can't sleep at all"},
     {"label": "Express a crisis", "text": "Honestly, sometimes I feel like I want to end it all"},
     {"label": "Show improvement", "text": "Talking this through actually helps — thank you"},
 ]
+
+# Session-scoped keys cleared between sessions.
+_SESSION_KEYS = (
+    "conversation", "conversation_model", "patient_profile", "session_risk_flags",
+    "session_topics", "session_suggestions", "latest_suggestions", "latest_analysis",
+    "history_summary", "doctor_notes_input", "demo_mode",
+)
+
+
+def _new_live_session(patient_id):
+    """Reset per-session state and start a fresh transcript for a patient."""
+    st.session_state.conversation = []
+    st.session_state.conversation_model = Conversation(
+        session_id=str(uuid.uuid4()), patient_id=patient_id, messages=[]
+    )
+    st.session_state.session_risk_flags = []
+    st.session_state.session_topics = []
+    st.session_state.session_suggestions = []
+    for k in ("latest_suggestions", "latest_analysis", "history_summary", "doctor_notes_input"):
+        st.session_state.pop(k, None)
 
 
 def start_demo(persona):
@@ -132,46 +151,82 @@ def start_demo(persona):
         "medical_history": list(persona["medical_history"]),
         "therapy_goals": list(persona["therapy_goals"]),
     }
-    st.session_state.conversation = []
-    st.session_state.conversation_model = Conversation(
-        session_id=str(uuid.uuid4()), patient_id=persona["patient_id"], messages=[]
-    )
-    st.session_state.session_risk_flags = []
-    st.session_state.session_topics = []
+    _new_live_session(persona["patient_id"])
     st.session_state.page = "chat"
     st.rerun()
 
 
 def reset_session():
     """Clear the session and return to the landing page."""
-    for key in (
-        "conversation", "conversation_model", "patient_profile",
-        "session_risk_flags", "session_topics", "demo_mode", "page",
-    ):
+    for key in _SESSION_KEYS + ("page",):
         st.session_state.pop(key, None)
     st.rerun()
 
 
-def handle_user_message(message):
-    """Run one patient message through the guidance pipeline and update state.
-
-    Shared by the chat input and the demo one-click prompts. Skips database
-    archiving in demo mode (the demo runs purely in-memory).
-    """
-    st.session_state.conversation.append({"role": "user", "content": message})
-    st.session_state.conversation_model.add_message(Message(content=message, is_user=True))
-
-    conversation_text = "\n".join(
-        f"{m['role'].capitalize()}: {m['content']}" for m in st.session_state.conversation
-    )
-
-    assistant_reply = "I'm sorry, something went wrong."
-    analytics = {"safety_protocol": _safety_checker.check_input(message)}
-
+def _load_history_summary():
     try:
-        with st.status("Analyzing the patient message…", expanded=True) as status:
-            analysis = analyze_message(message, st.session_state.patient_profile, conversation_text)
+        pid = st.session_state.conversation_model.patient_id
+        sid = st.session_state.conversation_model.session_id
+        sessions = [s for s in get_patient_sessions(pid) if s.get("session_id") != sid]
+        return build_history_summary(sessions)
+    except Exception:
+        logger.exception("Failed to load patient history summary")
+        return "(no prior sessions)"
 
+
+def _format_signals(analysis):
+    a = analysis or {}
+    urgency = a.get("urgency") or {}
+    sp = a.get("safety_protocol")
+    return "; ".join([
+        f"topic: {a.get('predicted_topic')} ({a.get('topic_confidence')})",
+        f"sentiment: {a.get('sentiment')} ({a.get('sentiment_score')})",
+        f"emotion: {urgency.get('label')} ({urgency.get('score')})",
+        f"crisis flag: {(sp.get('flag_type') + '/' + sp.get('action')) if sp else 'none'}",
+    ])
+
+
+def _persist_session():
+    """Archive the transcript + session log unless this is an in-memory demo."""
+    if st.session_state.get("demo_mode"):
+        return
+    try:
+        archive_conversation(st.session_state.conversation_model)
+    except Exception:
+        logger.exception("Failed to archive conversation")
+    try:
+        latest = st.session_state.get("latest_analysis") or {}
+        archive_session(SessionLog(
+            session_id=st.session_state.conversation_model.session_id,
+            patient_id=st.session_state.conversation_model.patient_id,
+            detected_topics=st.session_state.session_topics,
+            risk_flags=st.session_state.session_risk_flags,
+            sentiment_score=float(latest.get("sentiment_score") or 0.0),
+            doctor_notes=st.session_state.get("doctor_notes_input", ""),
+            suggestions=st.session_state.get("session_suggestions", []),
+        ))
+    except Exception:
+        logger.exception("Failed to archive session log")
+
+
+def _run_assistant(patient_text):
+    """Analyze a patient turn and generate decision-support for the doctor."""
+    transcript = "\n".join(
+        f"{m.get('speaker', 'patient').capitalize()}: {m['content']}"
+        for m in st.session_state.conversation
+    )
+    doctor_questions = "\n".join(
+        m["content"] for m in st.session_state.conversation if m.get("speaker") == "doctor"
+    ) or "(none yet)"
+
+    if "history_summary" not in st.session_state:
+        st.session_state.history_summary = _load_history_summary()
+
+    analysis = {"safety_protocol": _safety_checker.check_input(patient_text)}
+    suggestions = {}
+    try:
+        with st.status("Analyzing the patient turn…", expanded=True) as status:
+            analysis = analyze_message(patient_text, st.session_state.patient_profile, transcript)
             sp = analysis.get("safety_protocol")
             st.write(f"Safety: {sp['action'] + ' — ' + sp['flag_type'] if sp else 'no crisis indicators'}")
             urgency = analysis.get("urgency") or {}
@@ -181,39 +236,48 @@ def handle_user_message(message):
                 f"Sentiment: {analysis.get('sentiment') or 'n/a'}"
             )
             st.write(f"Retrieved {len(analysis.get('historical_examples') or [])} similar case(s).")
-
-            status.update(label="Generating guidance…")
-            assistant_reply = st.write_stream(
-                stream_advice(analysis.get("analysis_context", ""), analysis.get("historical_examples"))
-            ) or "No advice available."
-            status.update(label="Guidance ready", state="complete", expanded=False)
-
-        analytics = {
-            "topic": analysis.get("predicted_topic"),
-            "topic_confidence": analysis.get("topic_confidence"),
-            "sentiment": analysis.get("sentiment"),
-            "sentiment_score": analysis.get("sentiment_score"),
-            "safety_protocol": analysis.get("safety_protocol"),
-            "urgency": analysis.get("urgency"),
-            # Kept in session state only (not archived) for the "why this guidance" panel.
-            "historical_examples": analysis.get("historical_examples"),
-            "analysis_context": analysis.get("analysis_context"),
-        }
+            status.update(label="Generating decision support…")
+            suggestions = generate_session_suggestions(
+                transcript=transcript,
+                patient_summary=build_patient_summary(st.session_state.patient_profile),
+                history_summary=st.session_state.history_summary,
+                signals=_format_signals(analysis),
+                examples=analysis.get("historical_examples"),
+                doctor_questions=doctor_questions,
+            )
+            status.update(label="Decision support ready", state="complete", expanded=False)
     except Exception:
-        logger.exception("Guidance generation error")
-        analytics = {"safety_protocol": _safety_checker.check_input(message)}
+        logger.exception("Assistant generation error")
 
-    st.session_state.conversation.append({
-        "role": "assistant",
-        "content": assistant_reply,
-        "analysis": analytics,
+    st.session_state.latest_analysis = analysis
+    st.session_state.latest_suggestions = suggestions
+
+    analytics = {
+        "topic": analysis.get("predicted_topic"),
+        "topic_confidence": analysis.get("topic_confidence"),
+        "sentiment": analysis.get("sentiment"),
+        "sentiment_score": analysis.get("sentiment_score"),
+        "safety_protocol": analysis.get("safety_protocol"),
+        "urgency": analysis.get("urgency"),
+        # Session-state only (not archived) for the "why" panel.
+        "historical_examples": analysis.get("historical_examples"),
+        "analysis_context": analysis.get("analysis_context"),
+    }
+    # Attach analytics to the patient turn (feeds the metrics dashboard).
+    if st.session_state.conversation:
+        st.session_state.conversation[-1]["analysis"] = analytics
+    lean = {k: analytics.get(k) for k in
+            ("topic", "topic_confidence", "sentiment", "sentiment_score", "safety_protocol", "urgency")}
+    if st.session_state.conversation_model.messages:
+        st.session_state.conversation_model.messages[-1].metadata = lean
+
+    # Audit trail entry.
+    st.session_state.session_suggestions.append({
+        "turn": patient_text,
+        "suggestions": {k: suggestions.get(k) for k in
+                        ("emotional_state", "next_questions", "red_flags", "missing_info", "follow_ups")},
+        "safety": analytics.get("safety_protocol"),
     })
-    # Archived metadata stays lean (no retrieved examples / raw context).
-    lean_metadata = {k: analytics.get(k) for k in
-                     ("topic", "topic_confidence", "sentiment", "sentiment_score", "safety_protocol", "urgency")}
-    st.session_state.conversation_model.add_message(
-        Message(content=assistant_reply, is_user=False, metadata=lean_metadata)
-    )
 
     # Roll up distinct risk flags + topics for the session.
     protocol = analytics.get("safety_protocol")
@@ -224,55 +288,44 @@ def handle_user_message(message):
     if topic and topic not in st.session_state.session_topics:
         st.session_state.session_topics.append(topic)
 
-    # Persist to the database unless this is an in-memory demo session.
-    if not st.session_state.get("demo_mode"):
-        archive_conversation(st.session_state.conversation_model)
-        try:
-            archive_session(SessionLog(
-                session_id=st.session_state.conversation_model.session_id,
-                patient_id=st.session_state.conversation_model.patient_id,
-                detected_topics=st.session_state.session_topics,
-                risk_flags=st.session_state.session_risk_flags,
-                sentiment_score=float(analytics.get("sentiment_score") or 0.0),
-            ))
-        except Exception:
-            logger.exception("Failed to archive session log")
 
+def handle_turn(content, speaker):
+    """Append a transcript turn. Patient turns trigger the assistant; doctor
+    turns are logged as context only."""
+    is_patient = speaker == "patient"
+    st.session_state.conversation.append({"speaker": speaker, "content": content})
+    st.session_state.conversation_model.add_message(
+        Message(content=content, is_user=is_patient, speaker=speaker)
+    )
+    if is_patient:
+        _run_assistant(content)
+    _persist_session()
     st.rerun()
 
 
 # Landing Page
 def landing_page():
     st.markdown("""
-        <div style='text-align:center; padding:20px;'>
-            <h1>Welcome to the Mental Health Counselor Guidance System</h1>
-            <p style='font-size:18px;'>
-                This AI-driven application provides tailored counseling advice based on patient conversations.
-                <br><br><b>Capabilities:</b>
-                <br>- Personalized recommendations
-                <br>- Conversation analysis (topics & sentiment)
-                <br>- Comprehensive reporting
-                <br><br><b>Limitations:</b>
-                <br>- Advisory only; professional judgment required
-                <br>- Use anonymized data only
-                <br>- Operations may be resource-intensive
-                <br><br><b>Instructions:</b>
-                <br>1. Click "Get Started" to begin chatting.
-                <br>2. Interact naturally with the assistant.
-                <br>3. Generate detailed reports when finished.
+        <div style='text-align:center; padding:16px;'>
+            <h1>🩺 Live Session Assistant</h1>
+            <p style='font-size:17px;'>
+                A real-time co-pilot for mental-health clinicians. Enter a patient ID to load their
+                history, then log the live session — the assistant suggests the patient's likely state,
+                next questions to ask, follow-ups, and red flags.
+                <br><br><b>Decision support only — not a diagnosis. The clinician stays in control.</b>
             </p>
         </div>
         """, unsafe_allow_html=True)
 
     patient_id = st.text_input("Patient ID", key="patient_id_input")
     medical_history_input = st.text_area(
-        "Medical history (optional, one item per line)", key="medical_history_input"
+        "Clinical history (optional, one item per line)", key="medical_history_input"
     )
     therapy_goals_input = st.text_area(
         "Therapy goals (optional, one item per line)", key="therapy_goals_input"
     )
 
-    if st.button("Get Started"):
+    if st.button("Open session"):
         patient_id = patient_id.strip()
         if not patient_id:
             st.error("Please enter a patient ID before starting.")
@@ -285,14 +338,11 @@ def landing_page():
             profile = get_patient_profile(patient_id)
             if profile is None:
                 profile = create_patient_profile(
-                    patient_id,
-                    medical_history=medical_history,
-                    therapy_goals=therapy_goals,
+                    patient_id, medical_history=medical_history, therapy_goals=therapy_goals,
                 )
             elif (medical_history and not profile.medical_history) or (
                 therapy_goals and not profile.therapy_goals
             ):
-                # Enrich a previously-empty profile with the entered details.
                 profile = update_patient_fields(
                     patient_id,
                     medical_history=medical_history or profile.medical_history,
@@ -303,22 +353,25 @@ def landing_page():
             st.error("Could not load the patient profile. Please try again later.")
             return
 
+        st.session_state.demo_mode = False
         st.session_state.patient_profile = profile.dict()
-        st.session_state.conversation_model.patient_id = patient_id
+        _new_live_session(patient_id)
         st.session_state.page = "chat"
         st.rerun()
 
     st.divider()
     st.markdown("#### Or try a live demo")
-    st.caption("Explore the tool with a sample patient — no patient ID or setup needed.")
+    st.caption("Explore the assistant with a sample patient — no patient ID or setup needed.")
     demo_cols = st.columns(len(DEMO_PERSONAS))
     for i, (name, persona) in enumerate(DEMO_PERSONAS.items()):
         if demo_cols[i].button(name, key=f"demo_persona_{i}", use_container_width=True):
             start_demo(persona)
 
+
 # Chat Page
 def chat_page():
-    st.title("🧠 Mental Health Counselor Guidance")
+    st.title("🩺 Live Session Assistant")
+    st.caption("Decision support for the clinician — not a diagnosis. You stay in control.")
 
     ctrl_left, ctrl_right = st.columns([3, 1])
     if st.session_state.get("demo_mode"):
@@ -326,110 +379,94 @@ def chat_page():
     if ctrl_right.button("New session", use_container_width=True):
         reset_session()
 
-    col_chat, col_dash = st.columns([1.4, 1], gap="large")
+    render_patient_overview(
+        st.session_state.conversation_model.patient_id,
+        st.session_state.get("patient_profile") or {},
+        exclude_session_id=st.session_state.conversation_model.session_id,
+    )
+    st.divider()
+
+    col_chat, col_dash = st.columns([1.3, 1], gap="large")
 
     with col_chat:
-        # Display messages freshly each time using Streamlit's native chat components
+        st.markdown("##### Live transcript")
         for msg in st.session_state.conversation:
-            if msg["role"] == "user":
-                with st.chat_message("user"):
-                    st.write(msg["content"])
-            else:
-                with st.chat_message("assistant"):
-                    render_advice(msg["content"])
-                    analysis = msg.get("analysis")
-                    if analysis:
-                        st.caption(
-                            f"Topic: {analysis.get('topic')} (Confidence: {analysis.get('topic_confidence', 0.0):.2f}) | "
-                            f"Sentiment: {analysis.get('sentiment')} ({analysis.get('sentiment_score')})"
-                        )
+            speaker = msg.get("speaker") or ("patient" if msg.get("role") == "user" else "doctor")
+            avatar = "🩺" if speaker == "doctor" else "🧑"
+            with st.chat_message(speaker, avatar=avatar):
+                st.markdown(f"**{speaker.capitalize()}:** {msg['content']}")
 
-                        safety_protocol = analysis.get("safety_protocol")
-                        if safety_protocol:
-                            action = safety_protocol.get("action", "URGENT")
-                            banner = (
-                                f"⚠️ Crisis indicator detected ({action}). "
-                                f"Suggested protocol: {safety_protocol.get('response', '')}"
-                            )
-                            if action == "CRITICAL":
-                                st.error(banner)
-                            else:
-                                st.warning(banner)
-
-                        # Only show the urgency banner when there is no crisis banner
-                        # already (the crisis banner takes priority and conveys urgency).
-                        urgency = analysis.get("urgency")
-                        if urgency and urgency.get("is_urgent") and not safety_protocol:
-                            score = urgency.get("score")
-                            score_text = f" ({score:.2f})" if isinstance(score, (int, float)) else ""
-                            st.warning(
-                                f"Elevated emotional urgency: {urgency.get('label')}{score_text}"
-                            )
-
-                        render_why(analysis)
+        if st.session_state.get("demo_mode"):
+            st.caption("Quick demo patient turns")
+            prompt_cols = st.columns(len(SUGGESTED_PROMPTS))
+            for i, prompt in enumerate(SUGGESTED_PROMPTS):
+                if prompt_cols[i].button(prompt["label"], key=f"suggested_{i}", use_container_width=True):
+                    handle_turn(prompt["text"], "patient")
 
     with col_dash:
-        render_dashboard(
-            st.session_state.conversation,
-            st.session_state.get("patient_profile") or {},
+        st.markdown("##### Session assistant")
+        render_suggestions(
+            st.session_state.get("latest_suggestions") or {},
+            st.session_state.get("latest_analysis") or {},
         )
+        with st.expander("Session metrics", expanded=False):
+            render_dashboard(st.session_state.conversation, st.session_state.get("patient_profile") or {})
 
-    # Demo: one-click messages that walk a distress -> crisis -> recovery arc.
-    if st.session_state.get("demo_mode"):
-        st.caption("Quick demo messages")
-        prompt_cols = st.columns(len(SUGGESTED_PROMPTS))
-        for i, prompt in enumerate(SUGGESTED_PROMPTS):
-            if prompt_cols[i].button(prompt["label"], key=f"suggested_{i}", use_container_width=True):
-                handle_user_message(prompt["text"])
+        st.text_area("Doctor notes", key="doctor_notes_input", height=100,
+                     placeholder="Your observations, overrides, plan…")
 
-    # Chat input
-    user_message = st.chat_input("Type your message here...")
-    if user_message:
-        handle_user_message(user_message)
+        audit = st.session_state.get("session_suggestions") or []
+        if audit:
+            with st.expander(f"Assistant audit trail ({len(audit)})"):
+                for i, entry in enumerate(audit, 1):
+                    s = entry.get("suggestions") or {}
+                    st.markdown(f"**Turn {i}** — _{(entry.get('turn') or '')[:60]}_")
+                    if s.get("emotional_state"):
+                        st.caption(f"state: {s['emotional_state']}")
+                    if s.get("next_questions"):
+                        st.caption("asked to consider: " + " | ".join(s["next_questions"][:3]))
+                    if entry.get("safety"):
+                        st.caption(f"safety: {entry['safety'].get('flag_type')}")
 
-    # Report generation section with spinner
-    if st.button("Exit Conversation and Show Report", key="exit_button", help="Generate detailed patient report"):
-        with st.spinner("Generating your detailed patient report..."):
-            try:
-                conversation_text = "\n".join(
-                    f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.conversation
-                )
-                
-                # Predict primary topic and confidence
-                classifier = load_topic_classifier()
-                predicted_topic, topic_confidence = predict_topic(conversation_text, classifier)
-                
-                # Evaluate overall sentiment
-                sentiment, sentiment_score = analyze_sentiment(conversation_text)
-                
-                # Prepare a structured prompt for generating actionable recommendations
-                prompt = (
-                    f"Patient Report Analysis:\n"
-                    f"Topic: {predicted_topic} (Confidence: {topic_confidence:.2f})\n"
-                    f"Overall Sentiment: {sentiment} (Score: {sentiment_score})\n\n"
-                    "Please provide a well-structured patient report with the following sections:\n"
-                    "1. **Strengths & Positive Aspects**: Highlight any positive observations.\n"
-                    "2. **Areas of Concern**: Identify aspects that require further attention.\n"
-                    "3. **Actionable Recommendations**: Offer clear, step-by-step advice for addressing challenges.\n"
-                    "Ensure that the report is organized with clear headings and bullet points."
-                )
-                
-                recommendations_obj = generate_advice(prompt)
-                if isinstance(recommendations_obj, list) and hasattr(recommendations_obj[0], "content"):
-                    recommendations = recommendations_obj[0].content
-                else:
-                    recommendations = str(recommendations_obj)
-                
-                st.divider()
-                st.subheader("📝 Patient Report")
-                st.markdown(f"**Predicted Topic:** {predicted_topic}  \n**Confidence:** {topic_confidence:.2f}")
-                st.markdown(f"**Overall Sentiment:** {sentiment}  \n**Sentiment Score:** {sentiment_score}")
-                st.markdown("### Recommendations")
-                st.markdown(recommendations)
-                
-            except Exception as e:
-                logger.exception("Error generating report")
-                st.error("An error occurred while generating the patient report. Please try again later.")
+    # Two-channel input: choose the speaker, then log the turn.
+    speaker_label = st.radio("Log turn as", ["Patient", "Doctor"], horizontal=True, key="speaker_select")
+    turn = st.chat_input(f"Log what the {speaker_label.lower()} said…")
+    if turn:
+        handle_turn(turn, "patient" if speaker_label == "Patient" else "doctor")
+
+    with st.expander("Generate end-of-session report"):
+        if st.button("Generate report", key="exit_button"):
+            with st.spinner("Generating the session report…"):
+                try:
+                    conversation_text = "\n".join(
+                        f"{m.get('speaker', 'patient').capitalize()}: {m['content']}"
+                        for m in st.session_state.conversation
+                    )
+                    classifier = load_topic_classifier()
+                    predicted_topic, topic_confidence = predict_topic(conversation_text, classifier)
+                    sentiment, sentiment_score = analyze_sentiment(conversation_text)
+                    prompt = (
+                        f"Patient Session Report:\n"
+                        f"Topic: {predicted_topic} (Confidence: {topic_confidence:.2f})\n"
+                        f"Overall Sentiment: {sentiment} (Score: {sentiment_score})\n\n"
+                        "Provide a structured clinician-facing session summary with sections:\n"
+                        "1. **Presentation & key themes**\n"
+                        "2. **Areas of concern / risk**\n"
+                        "3. **Suggested follow-up** (for the clinician to consider; not prescriptive).\n"
+                        "Use clear headings and bullet points. Do not diagnose or prescribe."
+                    )
+                    recommendations_obj = generate_advice(prompt)
+                    recommendations = (recommendations_obj if isinstance(recommendations_obj, str)
+                                       else str(recommendations_obj))
+                    st.divider()
+                    st.subheader("📝 Session report")
+                    st.markdown(f"**Predicted topic:** {predicted_topic} · **Confidence:** {topic_confidence:.2f}")
+                    st.markdown(f"**Overall sentiment:** {sentiment} ({sentiment_score})")
+                    st.markdown(recommendations)
+                except Exception:
+                    logger.exception("Error generating report")
+                    st.error("An error occurred while generating the report. Please try again later.")
+
 
 # Main Navigation
 if not check_authentication():

--- a/dashboard.py
+++ b/dashboard.py
@@ -2,8 +2,8 @@ import streamlit as st
 
 
 def _assistant_analyses(conversation):
-    """Per-message analytics dicts from the assistant turns of the conversation."""
-    return [m.get("analysis") or {} for m in (conversation or []) if m.get("role") == "assistant"]
+    """Per-message analytics dicts from any analyzed turn of the conversation."""
+    return [m["analysis"] for m in (conversation or []) if m.get("analysis")]
 
 
 def render_dashboard(conversation, patient_profile):

--- a/patient_overview.py
+++ b/patient_overview.py
@@ -1,0 +1,97 @@
+def _fmt_date(value):
+    if not value:
+        return "—"
+    try:
+        if hasattr(value, "strftime"):
+            return value.strftime("%Y-%m-%d")
+        return str(value)[:10]
+    except Exception:
+        return str(value)[:10]
+
+
+def build_patient_summary(profile):
+    """Compact text summary of the patient record for the LLM prompt."""
+    profile = profile or {}
+    parts = [f"patient_id: {profile.get('patient_id', '')}"]
+    mh = profile.get("medical_history") or []
+    tg = profile.get("therapy_goals") or []
+    if mh:
+        parts.append("medical history: " + "; ".join(mh))
+    if tg:
+        parts.append("therapy goals: " + "; ".join(tg))
+    return "\n".join(parts)
+
+
+def build_history_summary(sessions, limit=5):
+    """Compact text summary of prior sessions for the LLM prompt."""
+    if not sessions:
+        return "(no prior sessions)"
+    lines = []
+    for s in sessions[:limit]:
+        date = _fmt_date(s.get("created_at"))
+        topics = ", ".join(s.get("detected_topics") or []) or "—"
+        flags = ", ".join(s.get("risk_flags") or [])
+        flag_txt = f"; risk flags: {flags}" if flags else ""
+        lines.append(f"{date}: {topics}{flag_txt}")
+    return "\n".join(lines)
+
+
+def render_patient_overview(patient_id, profile=None, exclude_session_id=None):
+    """Top patient-context card + collapsible history timeline for the doctor.
+
+    Reads the profile (passed in to avoid a re-fetch) and the patient's prior
+    session logs. ``exclude_session_id`` drops the in-progress session so the
+    counts/timeline reflect *prior* context.
+    """
+    import streamlit as st
+    from patient_profile import get_patient_sessions
+
+    profile = profile or {}
+    medical_history = profile.get("medical_history") or []
+    therapy_goals = profile.get("therapy_goals") or []
+
+    try:
+        sessions = get_patient_sessions(patient_id)
+    except Exception:
+        sessions = []
+    if exclude_session_id:
+        sessions = [s for s in sessions if s.get("session_id") != exclude_session_id]
+
+    last = sessions[0] if sessions else None
+
+    cols = st.columns([2, 1, 1])
+    cols[0].markdown(f"**Patient** `{patient_id}`")
+    cols[1].metric("Past sessions", len(sessions))
+    cols[2].metric("Last seen", _fmt_date(last.get("created_at")) if last else "—")
+
+    if medical_history:
+        st.markdown("**Clinical history:** " + " · ".join(f"`{x}`" for x in medical_history))
+    if therapy_goals:
+        st.markdown("**Therapy goals:** " + ", ".join(therapy_goals))
+
+    if last:
+        bits = []
+        topics = last.get("detected_topics") or []
+        flags = last.get("risk_flags") or []
+        score = last.get("sentiment_score")
+        if topics:
+            bits.append("topics: " + ", ".join(topics))
+        if flags:
+            bits.append("risk flags: " + ", ".join(flags))
+        if isinstance(score, (int, float)):
+            bits.append(f"sentiment {score:+.2f}")
+        if bits:
+            st.caption("Most recent session — " + " · ".join(bits))
+
+    if sessions:
+        with st.expander(f"Session history ({len(sessions)})"):
+            for s in sessions[:20]:
+                date = _fmt_date(s.get("created_at"))
+                topics = ", ".join(s.get("detected_topics") or []) or "—"
+                flags = ", ".join(s.get("risk_flags") or [])
+                flag_txt = f" · risk: {flags}" if flags else ""
+                score = s.get("sentiment_score")
+                score_txt = f" · sentiment {score:+.2f}" if isinstance(score, (int, float)) else ""
+                st.markdown(f"- **{date}** — {topics}{flag_txt}{score_txt}")
+    else:
+        st.caption("No prior sessions on record for this patient.")

--- a/patient_profile.py
+++ b/patient_profile.py
@@ -16,6 +16,18 @@ def get_patient_conversation(patient_id: str):
     return conv
 
 
+def get_patient_sessions(patient_id: str):
+    """Return the patient's past session logs (raw dicts), most recent first."""
+    cursor = get_db()["sessions"].find({"patient_id": patient_id}).sort("created_at", -1)
+    return list(cursor)
+
+
+def get_patient_conversations(patient_id: str):
+    """Return the patient's archived conversations (raw dicts), most recent first."""
+    cursor = get_db()["PatientConvo"].find({"patient_id": patient_id}).sort("created_at", -1)
+    return list(cursor)
+
+
 def get_patient_profile(patient_id: str) -> PatientProfile | None:
     db = get_db()
     collection = db["patients"]

--- a/prompt_templates.py
+++ b/prompt_templates.py
@@ -9,3 +9,39 @@ ADVICE_TEMPLATE = ChatPromptTemplate.from_template(
     "Rationale: <brief justification>\n"
     "Suggested Actions: <numbered steps>\n"
 )
+
+
+# Decision-support for a clinician during a live session. Plain str.format
+# template (JSON braces are doubled). Reused by session_assistant.py.
+SESSION_ASSISTANT_TEMPLATE = (
+    "You are a clinical session co-pilot supporting a mental-health clinician during a live "
+    "session. You do NOT talk to the patient. You read the doctor-patient transcript and the "
+    "patient's record, and produce concise decision-support for the doctor.\n\n"
+    "PATIENT RECORD:\n{patient_summary}\n\n"
+    "PRIOR SESSIONS:\n{history_summary}\n\n"
+    "CURRENT-TURN SIGNALS (from analysis models):\n{signals}\n\n"
+    "SIMILAR PAST CASES (for grounding):\n{retrieved_cases}\n\n"
+    "QUESTIONS THE DOCTOR ALREADY ASKED THIS SESSION:\n{doctor_questions}\n\n"
+    "LIVE TRANSCRIPT (most recent last):\n{transcript}\n\n"
+    "Produce decision-support as STRICT JSON with exactly these keys:\n"
+    "{{\n"
+    '  "emotional_state": "<short grounded phrase for the patient\'s likely current state>",\n'
+    '  "state_confidence": "high|medium|low",\n'
+    '  "next_questions": ["<2-4 specific questions the doctor should consider asking next>"],\n'
+    '  "follow_ups": ["<points to circle back to later>"],\n'
+    '  "missing_info": ["<important information not yet clarified>"],\n'
+    '  "red_flags": ["<risk, contradiction, or concern> - <why, grounded in transcript/record>"],\n'
+    '  "caveat": "<optional one-line uncertainty note>"\n'
+    "}}\n\n"
+    "RULES:\n"
+    "- Ground every item in the transcript, the patient record, or the similar cases. If not "
+    "supported, omit it rather than invent it.\n"
+    "- Do NOT diagnose, prescribe medication, or state medical conclusions. Phrase questions as "
+    "'Consider asking...'. This is decision support; the clinician decides.\n"
+    "- Keep each item to a short phrase, not a paragraph. Be specific, not generic.\n"
+    "- Do NOT repeat questions the doctor already asked.\n"
+    "- Flag possible contradictions between what the patient says now vs earlier in the "
+    "transcript or the record.\n"
+    "- Make uncertainty explicit; prefer fewer high-value items over filler.\n"
+    "- Output ONLY the JSON object, with no prose before or after.\n"
+)

--- a/schemas.py
+++ b/schemas.py
@@ -5,6 +5,7 @@ from typing import List
 class Message(BaseModel):
     content: str
     is_user: bool
+    speaker: str = ""  # "doctor" | "patient" for two-channel session transcripts
     timestamp: datetime = Field(default_factory=datetime.now)
     metadata: dict = Field(default_factory=dict)
 
@@ -32,4 +33,6 @@ class SessionLog(BaseModel):
     recommendations: List[str] = Field(default_factory=list)
     risk_flags: List[str] = Field(default_factory=list)
     sentiment_score: float = 0.0
+    doctor_notes: str = ""
+    suggestions: List[dict] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=datetime.now)

--- a/session_assistant.py
+++ b/session_assistant.py
@@ -1,0 +1,162 @@
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+_EMPTY = {
+    "emotional_state": "",
+    "state_confidence": "low",
+    "next_questions": [],
+    "follow_ups": [],
+    "missing_info": [],
+    "red_flags": [],
+    "caveat": "",
+}
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _extract_json(text):
+    """Pull a JSON object out of a model reply, tolerating code fences/prose."""
+    if not text:
+        return None
+    s = text.strip()
+    if s.startswith("```"):
+        s = s.strip("`")
+        if s.lower().startswith("json"):
+            s = s[4:]
+    start, end = s.find("{"), s.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        s = s[start:end + 1]
+    try:
+        return json.loads(s)
+    except Exception:
+        return None
+
+
+def parse_suggestions(text):
+    """Parse the model's JSON decision-support into a normalized dict.
+
+    On unparseable output, returns the empty shape plus ``_raw`` so the raw
+    text can still be surfaced (nothing is silently dropped).
+    """
+    data = _extract_json(text)
+    if not isinstance(data, dict):
+        out = dict(_EMPTY)
+        out["_raw"] = (text or "").strip()
+        return out
+    return {
+        "emotional_state": str(data.get("emotional_state") or "").strip(),
+        "state_confidence": str(data.get("state_confidence") or "low").strip().lower(),
+        "next_questions": _as_list(data.get("next_questions")),
+        "follow_ups": _as_list(data.get("follow_ups")),
+        "missing_info": _as_list(data.get("missing_info")),
+        "red_flags": _as_list(data.get("red_flags")),
+        "caveat": str(data.get("caveat") or "").strip(),
+    }
+
+
+def generate_session_suggestions(transcript, patient_summary, history_summary,
+                                 signals, examples, doctor_questions):
+    """Call the LLM for decision-support and return parsed suggestions.
+
+    The deterministic crisis flag is NOT produced here — it comes from
+    analyze_message's safety_protocol and is rendered first by render_suggestions.
+    """
+    from langchain.schema import HumanMessage
+    from model_cache import get_chat_groq
+    from prompt_templates import SESSION_ASSISTANT_TEMPLATE
+
+    cases_text = ""
+    for ex in (examples or [])[:3]:
+        cases_text += (
+            f"- Patient: {(ex.get('questionText') or '')[:200]}\n"
+            f"  Therapist: {(ex.get('answerText') or '')[:200]}\n"
+        )
+    prompt = SESSION_ASSISTANT_TEMPLATE.format(
+        patient_summary=patient_summary or "(none)",
+        history_summary=history_summary or "(no prior sessions)",
+        signals=signals or "(none)",
+        retrieved_cases=cases_text or "(none)",
+        doctor_questions=doctor_questions or "(none yet)",
+        transcript=transcript or "",
+    )
+    try:
+        response = get_chat_groq().invoke([HumanMessage(content=prompt)])
+        text = response.content if hasattr(response, "content") else str(response)
+        return parse_suggestions(text)
+    except Exception:
+        logger.exception("Session suggestion generation failed.")
+        return dict(_EMPTY)
+
+
+_CONF_LABEL = {
+    "high": "high confidence",
+    "medium": "medium confidence",
+    "low": "low confidence — treat as a hint",
+}
+
+
+def render_suggestions(data, analysis):
+    """Render the assistant panel: deterministic safety first, then LLM aids."""
+    import streamlit as st
+    from explain import render_why
+
+    data = data or {}
+    analysis = analysis or {}
+
+    # 1. Deterministic safety — never depends on the LLM.
+    sp = analysis.get("safety_protocol")
+    if sp:
+        st.error(
+            f"Safety — {sp.get('action')}: {sp.get('flag_type')}. {sp.get('response', '')}"
+        )
+
+    red = data.get("red_flags") or []
+    if red:
+        st.markdown("**Red flags / concerns**")
+        for item in red:
+            st.markdown(f"- {item}")
+
+    missing = data.get("missing_info") or []
+    if missing:
+        st.markdown("**Missing info to clarify**")
+        for item in missing:
+            st.markdown(f"- {item}")
+
+    state = data.get("emotional_state")
+    if state:
+        conf = _CONF_LABEL.get((data.get("state_confidence") or "low"), _CONF_LABEL["low"])
+        st.markdown(f"**Likely state** — {state}")
+        st.caption(conf)
+
+    questions = data.get("next_questions") or []
+    if questions:
+        st.markdown("**Next questions to consider**")
+        for q in questions:
+            st.markdown(f"- {q}")
+
+    follow_ups = data.get("follow_ups") or []
+    if follow_ups:
+        st.markdown("**Follow-up points**")
+        for item in follow_ups:
+            st.markdown(f"- {item}")
+
+    if data.get("caveat"):
+        st.caption(f"Note: {data['caveat']}")
+    if data.get("_raw"):
+        with st.expander("Raw assistant output (could not parse as JSON)"):
+            st.code(data["_raw"])
+
+    if not any(data.get(k) for k in ("red_flags", "missing_info", "emotional_state",
+                                     "next_questions", "follow_ups")) and not sp:
+        st.caption("No high-value suggestions for this turn.")
+
+    st.caption("Decision support — not a diagnosis. Clinical judgment required.")
+    render_why(analysis)

--- a/tests/test_session_assistant.py
+++ b/tests/test_session_assistant.py
@@ -1,0 +1,50 @@
+from session_assistant import parse_suggestions
+from patient_overview import build_patient_summary, build_history_summary
+
+
+def test_parse_valid_json():
+    d = parse_suggestions(
+        '{"emotional_state":"anxious","state_confidence":"Medium",'
+        '"next_questions":["q1","q2"],"red_flags":["a - b"],'
+        '"missing_info":[],"follow_ups":["f"],"caveat":"c"}'
+    )
+    assert d["emotional_state"] == "anxious"
+    assert d["state_confidence"] == "medium"  # normalized to lowercase
+    assert d["next_questions"] == ["q1", "q2"]
+    assert d["red_flags"] == ["a - b"]
+
+
+def test_parse_code_fenced_and_string_to_list():
+    d = parse_suggestions('```json\n{"emotional_state":"sad","next_questions":"just one"}\n```')
+    assert d["emotional_state"] == "sad"
+    assert d["next_questions"] == ["just one"]
+
+
+def test_parse_prose_wrapped():
+    d = parse_suggestions('Sure, here it is: {"emotional_state":"ok","red_flags":["a"]} hope it helps')
+    assert d["emotional_state"] == "ok"
+    assert d["red_flags"] == ["a"]
+
+
+def test_parse_malformed_fallback_keeps_raw():
+    d = parse_suggestions("not json at all")
+    assert d["_raw"] == "not json at all"
+    assert d["next_questions"] == [] and d["emotional_state"] == ""
+
+
+def test_parse_empty():
+    d = parse_suggestions("")
+    assert d["_raw"] == "" and d["next_questions"] == []
+
+
+def test_build_patient_summary():
+    s = build_patient_summary({"patient_id": "P1", "medical_history": ["GAD"], "therapy_goals": ["sleep"]})
+    assert "patient_id: P1" in s and "GAD" in s and "sleep" in s
+
+
+def test_build_history_summary():
+    assert build_history_summary([]) == "(no prior sessions)"
+    s = build_history_summary([
+        {"created_at": "2026-06-01T00:00:00", "detected_topics": ["anxiety"], "risk_flags": ["suicide_risk"]}
+    ])
+    assert "2026-06-01" in s and "anxiety" in s and "suicide_risk" in s


### PR DESCRIPTION
## Summary
Evolves the app from a 2-party counseling chatbot into a **doctor live-session co-pilot** (mental-health/psychiatry). The AI is no longer a chat participant — it observes the doctor-patient dialogue and feeds the clinician a concise, grounded side panel. Decisions confirmed with the user: mental-health scope, **two-channel transcript** (doctor + patient turns), **MVP within Streamlit**. The clinician stays in control; suggestions are grounded, uncertainty-explicit, and never diagnostic/prescriptive.

## What's new
- **Patient history on load** — `get_patient_sessions` / `get_patient_conversations` (list+sort); a patient-overview card (id, # past sessions, last seen, clinical-history chips, therapy goals, last-session state) + a collapsible session timeline (`patient_overview.py`).
- **Two-channel transcript** — a speaker toggle (Patient/Doctor) logs each turn; doctor and patient turns render distinctly. Only patient turns trigger analysis + the assistant (`app_chat.py`).
- **Session assistant** (`session_assistant.py` + `SESSION_ASSISTANT_TEMPLATE`) — the LLM returns STRICT JSON: likely emotional state + confidence, next questions to consider, follow-ups, missing info, red flags. Rendered in priority order with the **deterministic crisis flag first** (never LLM-dependent), confidence badges, a grounding ("why") toggle, and a decision-support disclaimer. Robust JSON parser with a raw-text fallback.
- **Doctor notes + audit trail** — a notes area persisted to `SessionLog.doctor_notes`; per-turn suggestions recorded to `SessionLog.suggestions` and shown in an audit expander.
- **Schema** — `Message.speaker`; `SessionLog.doctor_notes` / `suggestions` (additive). The metrics dashboard now reads analyses from analyzed turns.

## Reuse
Built on the existing `analyze_message` (signals/RAG/context), `semantic_search` (grounding), `safety` (deterministic red flags), `dashboard`/`explain` helpers, `archiver`/`db` persistence, and demo mode. `generate_counselor_guidance`/`stream_advice` left intact for the FastAPI/CLI.

## Testing
- Unit: `tests/test_session_assistant.py` — JSON parser (valid/fenced/prose/malformed) + summary builders (pure, no deps). All pass.
- Live (Groq/Pinecone/Mongo): a crisis transcript produced `suicide_risk/CRITICAL` (deterministic) + grounded JSON — state "Overwhelmed and hopeless", 3 specific next questions, a red flag quoting the patient, missing-info — with no parse fallback.
- UI (demo mode): persona → session renders the overview card + transcript + assistant panel + notes + audit + disclaimer; a patient turn fills the panel (state/next-questions/red-flags/missing-info) with the safety banner first; the audit trail grows per turn; the warm second turn is faster (topic-model cache).