### PR TITLE
Use a non-Atlas host in safe_mongo_uri tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ def test_safe_mongo_uri_encodes_standard_scheme():
 def test_safe_mongo_uri_handles_srv_scheme():
     # Regression: the +srv (Atlas) scheme was previously not matched, so
     # credentials were never encoded.
-    s = Settings(mongo_uri="mongodb+srv://admin:p@ss@cluster0.abc.mongodb.net")
+    s = Settings(mongo_uri="mongodb+srv://admin:p@ss@cluster0.example.invalid")
     out = s.safe_mongo_uri
     assert out.startswith("mongodb+srv://")
     assert "p%40ss" in out
@@ -24,6 +24,6 @@ def test_safe_mongo_uri_passthrough_without_credentials():
 
 def test_safe_mongo_uri_does_not_double_encode():
     # Regression: an already-encoded password must stay %40, not become %2540.
-    s = Settings(mongo_uri="mongodb+srv://admin:p%40ss@cluster0.abc.mongodb.net")
+    s = Settings(mongo_uri="mongodb+srv://admin:p%40ss@cluster0.example.invalid")
     out = s.safe_mongo_uri
     assert "%40" in out and "%2540" not in out


### PR DESCRIPTION
The synthetic test URIs used a *.mongodb.net host, which GitHub secret scanning flagged as a MongoDB Atlas credential (false positive). Switch the fake host to .example.invalid; the encoding logic under test is host-agnostic so the tests are unchanged in intent.