### PR TITLE
Rebuild the UI as a three-column live-session cockpit

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -3,8 +3,8 @@ runOnSave = false
 
 [theme]
 base = "light"
-primaryColor = "#2E7D6B"
-backgroundColor = "#FFFFFF"
-secondaryBackgroundColor = "#F4F7F6"
-textColor = "#1F2933"
+primaryColor = "#3563d4"
+backgroundColor = "#eef1f6"
+secondaryBackgroundColor = "#ffffff"
+textColor = "#1a2235"
 font = "sans serif"

--- a/app_chat.py
+++ b/app_chat.py
@@ -3,6 +3,8 @@ import hmac
 import streamlit as st
 import logging
 import uuid
+from datetime import datetime
+import ui
 from logging_config import setup_logging
 from unified_guidance import analyze_message
 from archiver import archive_conversation, archive_session
@@ -63,16 +65,8 @@ st.set_page_config(
     initial_sidebar_state="collapsed"
 )
 
-# Hide default Streamlit chrome and apply light layout polish.
-st.markdown("""
-<style>
-#MainMenu, footer, header {visibility: hidden;}
-.block-container {padding-top: 2.5rem; max-width: 1200px;}
-[data-testid="stChatMessage"] {padding: 0.2rem 0;}
-[data-testid="stMetric"] {background: var(--secondary-background-color, #F4F7F6);
-    border-radius: 10px; padding: 10px 14px;}
-</style>
-""", unsafe_allow_html=True)
+# Cockpit theme: hide default chrome, fonts, widget styling, segmented toggle.
+st.markdown(ui.css(), unsafe_allow_html=True)
 
 # Initialize session state
 if "page" not in st.session_state:
@@ -128,7 +122,7 @@ SUGGESTED_PROMPTS = [
 _SESSION_KEYS = (
     "conversation", "conversation_model", "patient_profile", "session_risk_flags",
     "session_topics", "session_suggestions", "latest_suggestions", "latest_analysis",
-    "history_summary", "doctor_notes_input", "demo_mode",
+    "history_summary", "doctor_notes_input", "demo_mode", "session_started", "last_report",
 )
 
 
@@ -141,7 +135,9 @@ def _new_live_session(patient_id):
     st.session_state.session_risk_flags = []
     st.session_state.session_topics = []
     st.session_state.session_suggestions = []
-    for k in ("latest_suggestions", "latest_analysis", "history_summary", "doctor_notes_input"):
+    st.session_state.session_started = datetime.now()
+    for k in ("latest_suggestions", "latest_analysis", "history_summary",
+              "doctor_notes_input", "last_report"):
         st.session_state.pop(k, None)
 
 
@@ -316,7 +312,10 @@ def handle_turn(content, speaker):
     """Append a transcript turn. Patient turns trigger the assistant; doctor
     turns are logged as context only."""
     is_patient = speaker == "patient"
-    st.session_state.conversation.append({"speaker": speaker, "content": content})
+    st.session_state.conversation.append({
+        "speaker": speaker, "content": content,
+        "time": datetime.now().strftime("%H:%M"),
+    })
     st.session_state.conversation_model.add_message(
         Message(content=content, is_user=is_patient, speaker=speaker)
     )
@@ -326,188 +325,282 @@ def handle_turn(content, speaker):
     st.rerun()
 
 
-# Landing Page
+# --------------------------------------------------------------- cockpit glue
+def _elapsed_clock():
+    """mm:ss since the session started (updates each rerun, not live-ticking)."""
+    start = st.session_state.get("session_started")
+    if not start:
+        return "00:00"
+    secs = max(0, int((datetime.now() - start).total_seconds()))
+    return f"{secs // 60:02d}:{secs % 60:02d}"
+
+
+# Per-message transcript chips: (text, background, color).
+_AMBER = ("#fbf3e4", "#8a6a1f")
+_TOPIC = ("#eaf0fd", "#3052b8")
+
+
+def _transcript_messages():
+    """Adapt the live conversation into ui.transcript's message dicts, attaching
+    emotion/sentiment/topic chips and the crisis flag to analyzed patient turns."""
+    out = []
+    for m in st.session_state.conversation:
+        speaker = m.get("speaker") or "patient"
+        entry = {"speaker": speaker, "text": m.get("content"),
+                 "time": m.get("time", ""), "chips": [], "crisis": False}
+        a = m.get("analysis")
+        if a and speaker == "patient":
+            chips = []
+            urgency = a.get("urgency") or {}
+            if urgency.get("label"):
+                score = urgency.get("score")
+                label = str(urgency["label"]).title()
+                txt = f"{label} · {score:.0%}" if isinstance(score, (int, float)) else label
+                chips.append((txt, *_AMBER))
+            ss = a.get("sentiment_score")
+            if isinstance(ss, (int, float)):
+                bg, col = (("#fdeceb", "#b23a31") if ss < 0
+                           else ("#e8f5ef", "#2f8f6b") if ss > 0 else ("#eef1f6", "#647089"))
+                chips.append((f"{ss:+.2f}", bg, col))
+            if a.get("topic"):
+                chips.append((str(a["topic"]), *_TOPIC))
+            entry["chips"] = chips
+            entry["crisis"] = bool(a.get("safety_protocol"))
+        out.append(entry)
+    return out
+
+
+_PIPELINE_DEFS = [
+    ("Crisis screen", "regex · deterministic"),
+    ("Emotion / urgency", "DistilRoBERTa"),
+    ("Sentiment", "RoBERTa 3-class"),
+    ("Topic", "BART zero-shot"),
+    ("Semantic retrieval", "MiniLM · Pinecone"),
+    ("Generating guidance", "Groq · llama-3.3-70b"),
+]
+
+
+def _pipeline_stages():
+    """Build the analysis-pipeline panel state from the latest turn's outcome."""
+    a = st.session_state.get("latest_analysis") or {}
+    sug = st.session_state.get("latest_suggestions") or {}
+    if not a.get("analysis_context") and not a.get("safety_protocol") and not st.session_state.conversation:
+        return ([{"label": l, "sub": s, "status": "pending"} for l, s in _PIPELINE_DEFS],
+                False, "IDLE")
+    errors = a.get("errors") or []
+    sp = a.get("safety_protocol")
+    status_for = lambda key: "pending" if key in errors else "done"
+    stages = [
+        {"label": "Crisis screen", "sub": "regex · deterministic",
+         "status": "alert" if sp else "done"},
+        {"label": "Emotion / urgency", "sub": "DistilRoBERTa", "status": status_for("urgency")},
+        {"label": "Sentiment", "sub": "RoBERTa 3-class", "status": status_for("analysis")},
+        {"label": "Topic", "sub": "BART zero-shot", "status": status_for("analysis")},
+        {"label": "Semantic retrieval", "sub": "MiniLM · Pinecone", "status": status_for("retrieval")},
+        {"label": "Generating guidance", "sub": "Groq · llama-3.3-70b",
+         "status": "alert" if sug.get("_error") else "done"},
+    ]
+    degraded = bool(errors) or bool(sug.get("_error"))
+    return stages, False, ("DEGRADED" if degraded else "COMPLETE")
+
+
+def _open_session(patient_id, medical_history, therapy_goals):
+    """Load/create the patient profile and switch to the live session."""
+    try:
+        profile = get_patient_profile(patient_id)
+        if profile is None:
+            profile = create_patient_profile(
+                patient_id, medical_history=medical_history, therapy_goals=therapy_goals,
+            )
+        elif (medical_history and not profile.medical_history) or (
+            therapy_goals and not profile.therapy_goals
+        ):
+            profile = update_patient_fields(
+                patient_id,
+                medical_history=medical_history or profile.medical_history,
+                therapy_goals=therapy_goals or profile.therapy_goals,
+            )
+    except Exception:
+        logger.exception("Failed to load or create patient profile")
+        st.error("Could not load the patient profile. Please try again later.")
+        return
+
+    st.session_state.demo_mode = False
+    st.session_state.patient_profile = profile.dict()
+    _new_live_session(patient_id)
+    st.session_state.page = "chat"
+    st.rerun()
+
+
+# Landing / launch screen
 def landing_page():
-    st.markdown("""
-        <div style='text-align:center; padding:16px;'>
-            <h1>🩺 Live Session Assistant</h1>
-            <p style='font-size:17px;'>
-                A real-time co-pilot for mental-health clinicians. Enter a patient ID to load their
-                history, then log the live session — the assistant suggests the patient's likely state,
-                next questions to ask, follow-ups, and red flags.
-                <br><br><b>Decision support only — not a diagnosis. The clinician stays in control.</b>
-            </p>
-        </div>
-        """, unsafe_allow_html=True)
+    _, mid, _ = st.columns([1, 2.2, 1])
+    with mid:
+        st.markdown(ui.launch_hero(), unsafe_allow_html=True)
 
-    patient_id = st.text_input("Patient ID", key="patient_id_input")
-    medical_history_input = st.text_area(
-        "Clinical history (optional, one item per line)", key="medical_history_input"
-    )
-    therapy_goals_input = st.text_area(
-        "Therapy goals (optional, one item per line)", key="therapy_goals_input"
-    )
+        patient_id = st.text_input("Patient ID", key="patient_id_input", placeholder="e.g. PT-0042")
+        with st.expander("Add clinical context (optional)"):
+            medical_history_input = st.text_area(
+                "Clinical history (one item per line)", key="medical_history_input"
+            )
+            therapy_goals_input = st.text_area(
+                "Therapy goals (one item per line)", key="therapy_goals_input"
+            )
 
-    if st.button("Open session"):
-        patient_id = patient_id.strip()
-        if not patient_id:
-            st.error("Please enter a patient ID before starting.")
-            return
-
-        medical_history = _parse_lines(medical_history_input)
-        therapy_goals = _parse_lines(therapy_goals_input)
-
-        try:
-            profile = get_patient_profile(patient_id)
-            if profile is None:
-                profile = create_patient_profile(
-                    patient_id, medical_history=medical_history, therapy_goals=therapy_goals,
-                )
-            elif (medical_history and not profile.medical_history) or (
-                therapy_goals and not profile.therapy_goals
-            ):
-                profile = update_patient_fields(
+        if st.button("Open session", type="primary", use_container_width=True):
+            patient_id = (patient_id or "").strip()
+            if not patient_id:
+                st.error("Please enter a patient ID before starting.")
+            else:
+                _open_session(
                     patient_id,
-                    medical_history=medical_history or profile.medical_history,
-                    therapy_goals=therapy_goals or profile.therapy_goals,
+                    _parse_lines(st.session_state.get("medical_history_input")),
+                    _parse_lines(st.session_state.get("therapy_goals_input")),
                 )
-        except Exception:
-            logger.exception("Failed to load or create patient profile")
-            st.error("Could not load the patient profile. Please try again later.")
-            return
 
-        st.session_state.demo_mode = False
-        st.session_state.patient_profile = profile.dict()
-        _new_live_session(patient_id)
-        st.session_state.page = "chat"
-        st.rerun()
+        st.markdown(
+            f'<div style="display:flex;align-items:center;gap:12px;margin:18px 0 12px;">'
+            f'<span style="flex:1;height:1px;background:#dde3ee;"></span>'
+            f'<span style="font:500 10.5px/1 {ui.MONO};color:#aab2c4;letter-spacing:.04em;">'
+            f'OR START WITH A DEMO PERSONA</span>'
+            f'<span style="flex:1;height:1px;background:#dde3ee;"></span></div>',
+            unsafe_allow_html=True,
+        )
+        demo_cols = st.columns(len(DEMO_PERSONAS))
+        for i, (name, persona) in enumerate(DEMO_PERSONAS.items()):
+            if demo_cols[i].button(name, key=f"demo_persona_{i}", use_container_width=True):
+                start_demo(persona)
 
-    st.divider()
-    st.markdown("#### Or try a live demo")
-    st.caption("Explore the assistant with a sample patient — no patient ID or setup needed.")
-    demo_cols = st.columns(len(DEMO_PERSONAS))
-    for i, (name, persona) in enumerate(DEMO_PERSONAS.items()):
-        if demo_cols[i].button(name, key=f"demo_persona_{i}", use_container_width=True):
-            start_demo(persona)
+        st.markdown(ui.launch_footer(), unsafe_allow_html=True)
 
 
-# Chat Page
+def _generate_report():
+    """Compute the end-of-session report from accumulated session signals."""
+    conv = st.session_state.conversation
+    # Classify over the patient's own turns (doctor questions skew topic/sentiment).
+    patient_text = "\n".join(m["content"] for m in conv if m.get("speaker") == "patient") \
+        or "\n".join(m["content"] for m in conv)
+    classifier = load_topic_classifier()
+    predicted_topic, topic_confidence = predict_topic(patient_text, classifier)
+    sentiment, sentiment_score = analyze_sentiment(patient_text)
+
+    risk_flags = st.session_state.get("session_risk_flags") or []
+    topics = st.session_state.get("session_topics") or []
+    notes = st.session_state.get("doctor_notes_input", "")
+    prompt = (
+        f"Patient Session Report:\n"
+        f"Topic: {predicted_topic} (Confidence: {topic_confidence:.2f})\n"
+        f"Topics observed this session: {', '.join(topics) or 'n/a'}\n"
+        f"Overall Sentiment: {sentiment} (Score: {sentiment_score})\n"
+        f"Risk flags raised this session: {', '.join(risk_flags) or 'none'}\n"
+        f"Clinician notes: {notes or '(none)'}\n\n"
+        "Provide a structured clinician-facing session summary with sections:\n"
+        "1. **Presentation & key themes**\n"
+        "2. **Areas of concern / risk** — explicitly address every risk flag listed above.\n"
+        "3. **Suggested follow-up** (for the clinician to consider; not prescriptive).\n"
+        "Use clear headings and bullet points. Do not diagnose or prescribe."
+    )
+    recommendations_obj = generate_advice(prompt)
+    recommendations = (recommendations_obj if isinstance(recommendations_obj, str)
+                       else str(recommendations_obj))
+    return {
+        "topic": predicted_topic, "topic_conf": topic_confidence,
+        "sentiment": sentiment, "score": sentiment_score,
+        "risk_flags": risk_flags, "topics": topics, "recommendations": recommendations,
+    }
+
+
+@st.dialog("End-of-session report", width="large")
+def _report_dialog():
+    pid = st.session_state.conversation_model.patient_id
+    st.caption(f"{pid} · {_elapsed_clock()} · {len(st.session_state.conversation)} turns logged")
+    if st.button("Generate / regenerate", type="primary") or "last_report" not in st.session_state:
+        with st.spinner("Generating the session report…"):
+            try:
+                st.session_state["last_report"] = _generate_report()
+            except Exception:
+                logger.exception("Error generating report")
+                st.session_state.pop("last_report", None)
+                st.error("An error occurred while generating the report. Please try again later.")
+                return
+    rep = st.session_state.get("last_report")
+    if not rep:
+        return
+    if rep["risk_flags"]:
+        st.error("**Risk flags raised this session:** " + ", ".join(rep["risk_flags"]))
+    st.markdown(f"**Predicted topic:** {rep['topic']} · **Confidence:** {rep['topic_conf']:.2f}")
+    st.markdown(f"**Overall sentiment:** {rep['sentiment']} ({rep['score']})")
+    if rep["topics"]:
+        st.caption("Topics detected: " + ", ".join(rep["topics"]))
+    st.markdown(rep["recommendations"])
+    st.caption("Decision support generated from session signals — not a diagnosis or medical "
+               "record. Review, edit, and sign before filing.")
+
+
+# Chat / cockpit page
 def chat_page():
-    st.title("🩺 Live Session Assistant")
-    st.caption("Decision support for the clinician — not a diagnosis. You stay in control.")
-
     # Surface a persistence failure from the previous turn (set just before the
     # rerun that brought us here, so it could not be shown inline).
     if st.session_state.pop("persist_error", False):
         st.warning("⚠️ The last turn may not have been saved to the database. "
                    "Check the patient profile exists and the database is reachable.")
 
-    ctrl_left, ctrl_right = st.columns([3, 1])
+    pid = st.session_state.conversation_model.patient_id
+    sid = st.session_state.conversation_model.session_id
+    conv = st.session_state.conversation
+    profile = st.session_state.get("patient_profile") or {}
+    latest_analysis = st.session_state.get("latest_analysis") or {}
+    latest_suggestions = st.session_state.get("latest_suggestions") or {}
+
+    st.markdown(ui.header_bar(pid, _elapsed_clock(), len(conv)), unsafe_allow_html=True)
+
+    c_info, c_report, c_new = st.columns([6, 1.6, 1.2])
     if st.session_state.get("demo_mode"):
-        ctrl_left.caption("Demo mode — sample patient, nothing is saved.")
-    if ctrl_right.button("New session", use_container_width=True):
+        c_info.caption("Demo mode — sample patient, nothing is saved.")
+    if c_report.button("End session & report", type="primary", use_container_width=True):
+        _report_dialog()
+    if c_new.button("New session", use_container_width=True):
         reset_session()
 
-    render_patient_overview(
-        st.session_state.conversation_model.patient_id,
-        st.session_state.get("patient_profile") or {},
-        exclude_session_id=st.session_state.conversation_model.session_id,
-    )
-    st.divider()
+    left, center, right = st.columns([316, 480, 404], gap="medium")
 
-    col_chat, col_dash = st.columns([1.3, 1], gap="large")
+    # LEFT — patient context + clinician notes
+    with left:
+        render_patient_overview(pid, profile, exclude_session_id=sid)
+        st.markdown('<div class="lsa-h" style="margin-top:4px;"><span class="bar"></span>'
+                    '<span class="t">CLINICIAN NOTES</span></div>', unsafe_allow_html=True)
+        st.text_area("Clinician notes", key="doctor_notes_input", height=110,
+                     label_visibility="collapsed",
+                     placeholder="Private notes for this session — saved with the session…")
 
-    with col_chat:
-        st.markdown("##### Live transcript")
-        for msg in st.session_state.conversation:
-            speaker = msg.get("speaker") or ("patient" if msg.get("role") == "user" else "doctor")
-            avatar = "🩺" if speaker == "doctor" else "🧑"
-            with st.chat_message(speaker, avatar=avatar):
-                st.markdown(f"**{speaker.capitalize()}:** {msg['content']}")
+    # CENTER — crisis banner + transcript + composer
+    with center:
+        sp = latest_analysis.get("safety_protocol")
+        if sp:
+            st.markdown(ui.crisis_banner(sp.get("action"), sp.get("flag_type"), sp.get("response")),
+                        unsafe_allow_html=True)
+        st.markdown(ui.transcript(_transcript_messages(), len(conv)), unsafe_allow_html=True)
 
+        speaker_label = st.radio("Log turn as", ["Patient", "Doctor"], horizontal=True,
+                                 key="speaker_select", label_visibility="collapsed")
         if st.session_state.get("demo_mode"):
             st.caption("Quick demo patient turns")
             prompt_cols = st.columns(len(SUGGESTED_PROMPTS))
-            for i, prompt in enumerate(SUGGESTED_PROMPTS):
-                if prompt_cols[i].button(prompt["label"], key=f"suggested_{i}", use_container_width=True):
-                    handle_turn(prompt["text"], "patient")
+            for i, p in enumerate(SUGGESTED_PROMPTS):
+                if prompt_cols[i].button(p["label"], key=f"suggested_{i}", use_container_width=True):
+                    handle_turn(p["text"], "patient")
 
-    with col_dash:
-        st.markdown("##### Session assistant")
-        render_suggestions(
-            st.session_state.get("latest_suggestions") or {},
-            st.session_state.get("latest_analysis") or {},
-        )
-        with st.expander("Session metrics", expanded=False):
-            render_dashboard(st.session_state.conversation, st.session_state.get("patient_profile") or {})
+    # RIGHT — analysis pipeline + decision support + session metrics
+    with right:
+        stages, running, status_label = _pipeline_stages()
+        st.markdown(ui.pipeline_panel(stages, running, status_label), unsafe_allow_html=True)
+        render_suggestions(latest_suggestions, latest_analysis)
+        render_dashboard(conv, profile)
 
-        st.text_area("Doctor notes", key="doctor_notes_input", height=100,
-                     placeholder="Your observations, overrides, plan…")
-
-        audit = st.session_state.get("session_suggestions") or []
-        if audit:
-            with st.expander(f"Assistant audit trail ({len(audit)})"):
-                for i, entry in enumerate(audit, 1):
-                    s = entry.get("suggestions") or {}
-                    st.markdown(f"**Turn {i}** — _{(entry.get('turn') or '')[:60]}_")
-                    if s.get("emotional_state"):
-                        st.caption(f"state: {s['emotional_state']}")
-                    if s.get("next_questions"):
-                        st.caption("asked to consider: " + " | ".join(s["next_questions"][:3]))
-                    if entry.get("safety"):
-                        st.caption(f"safety: {entry['safety'].get('flag_type')}")
-
-    # Two-channel input: choose the speaker, then log the turn.
-    speaker_label = st.radio("Log turn as", ["Patient", "Doctor"], horizontal=True, key="speaker_select")
+    # Pinned two-channel input.
     turn = st.chat_input(f"Log what the {speaker_label.lower()} said…")
     if turn:
         handle_turn(turn, "patient" if speaker_label == "Patient" else "doctor")
-
-    with st.expander("Generate end-of-session report"):
-        if st.button("Generate report", key="exit_button"):
-            with st.spinner("Generating the session report…"):
-                try:
-                    # Classify over the patient's own turns (the doctor's
-                    # questions would skew topic/sentiment).
-                    patient_text = "\n".join(
-                        m["content"] for m in st.session_state.conversation
-                        if m.get("speaker") == "patient"
-                    ) or "\n".join(m["content"] for m in st.session_state.conversation)
-                    classifier = load_topic_classifier()
-                    predicted_topic, topic_confidence = predict_topic(patient_text, classifier)
-                    sentiment, sentiment_score = analyze_sentiment(patient_text)
-
-                    # Carry the safety signals accumulated DURING the session
-                    # into the report — a crisis flagged earlier must not vanish.
-                    risk_flags = st.session_state.get("session_risk_flags") or []
-                    topics = st.session_state.get("session_topics") or []
-                    notes = st.session_state.get("doctor_notes_input", "")
-                    prompt = (
-                        f"Patient Session Report:\n"
-                        f"Topic: {predicted_topic} (Confidence: {topic_confidence:.2f})\n"
-                        f"Topics observed this session: {', '.join(topics) or 'n/a'}\n"
-                        f"Overall Sentiment: {sentiment} (Score: {sentiment_score})\n"
-                        f"Risk flags raised this session: {', '.join(risk_flags) or 'none'}\n"
-                        f"Clinician notes: {notes or '(none)'}\n\n"
-                        "Provide a structured clinician-facing session summary with sections:\n"
-                        "1. **Presentation & key themes**\n"
-                        "2. **Areas of concern / risk** — explicitly address every risk flag listed above.\n"
-                        "3. **Suggested follow-up** (for the clinician to consider; not prescriptive).\n"
-                        "Use clear headings and bullet points. Do not diagnose or prescribe."
-                    )
-                    recommendations_obj = generate_advice(prompt)
-                    recommendations = (recommendations_obj if isinstance(recommendations_obj, str)
-                                       else str(recommendations_obj))
-                    st.divider()
-                    st.subheader("📝 Session report")
-                    st.markdown(f"**Predicted topic:** {predicted_topic} · **Confidence:** {topic_confidence:.2f}")
-                    st.markdown(f"**Overall sentiment:** {sentiment} ({sentiment_score})")
-                    if risk_flags:
-                        st.error("**Risk flags raised this session:** " + ", ".join(risk_flags))
-                    st.markdown(recommendations)
-                except Exception:
-                    logger.exception("Error generating report")
-                    st.error("An error occurred while generating the report. Please try again later.")
 
 
 # Main Navigation

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import ui
 
 
 def _assistant_analyses(conversation):
@@ -6,86 +7,46 @@ def _assistant_analyses(conversation):
     return [m["analysis"] for m in (conversation or []) if m.get("analysis")]
 
 
-def render_dashboard(conversation, patient_profile):
-    """Render the live counselor dashboard from the conversation's analytics.
-
-    Reads only data already produced per message (sentiment, urgency/emotion,
-    topic, safety) — no model calls here.
-    """
-    st.subheader("Live session dashboard")
+def trajectory(conversation):
+    """Build the sentiment sparkline (points string + signed delta) from the
+    per-message sentiment scores. Mirrors the cockpit metric geometry."""
     analyses = _assistant_analyses(conversation)
-
-    if not analyses:
-        st.caption("Emotional and risk metrics appear here as the conversation progresses.")
-        _render_profile(patient_profile)
-        return
-
-    latest = analyses[-1]
-    flagged = [a.get("safety_protocol") for a in analyses if a.get("safety_protocol")]
-
-    # Current risk status
-    sp = latest.get("safety_protocol")
-    if sp:
-        label = f"Risk: {sp.get('action', 'URGENT')} — {sp.get('flag_type')}"
-        (st.error if sp.get("action") == "CRITICAL" else st.warning)(label)
-    elif flagged:
-        st.warning(f"Risk: {len(flagged)} flag(s) earlier this session")
+    scores = [a.get("sentiment_score") for a in analyses
+              if isinstance(a.get("sentiment_score"), (int, float))]
+    if len(scores) < 2:
+        return "", "—", "#8a93a8", False
+    n = len(scores)
+    pts = []
+    for i, v in enumerate(scores):
+        x = (i / (n - 1)) * 240
+        y = max(4.0, min(56.0, 30 - (v * 26)))
+        pts.append(f"{x:.1f},{y:.1f}")
+    delta = scores[-1] - scores[0]
+    if delta > 0.02:
+        txt, color = f"▲ +{delta:.2f}", "#2f8f6b"
+    elif delta < -0.02:
+        txt, color = f"▼ {delta:.2f}", "#b23a31"
     else:
-        st.success("Risk: none detected")
-
-    # Metric cards
-    c1, c2, c3 = st.columns(3)
-    score = latest.get("sentiment_score")
-    c1.metric("Sentiment", latest.get("sentiment") or "—",
-              f"{score:+.2f}" if isinstance(score, (int, float)) else None)
-    urgency = latest.get("urgency") or {}
-    emotion = urgency.get("label")
-    c2.metric("Emotion", emotion.title() if emotion else "—")
-    c3.metric("Topic", latest.get("topic") or "—")
-
-    bits = []
-    if isinstance(urgency.get("score"), (int, float)):
-        bits.append(f"emotion {urgency['score']:.0%}")
-    if isinstance(latest.get("topic_confidence"), (int, float)):
-        bits.append(f"topic {latest['topic_confidence']:.0%}")
-    if bits:
-        st.caption(" · ".join(bits) + " confidence")
-
-    # Emotional trajectory
-    scores = [a.get("sentiment_score") for a in analyses if isinstance(a.get("sentiment_score"), (int, float))]
-    if len(scores) >= 2:
-        st.caption("Emotional trajectory · sentiment per message")
-        st.line_chart(scores, height=160)
-
-    # Safety timeline
-    if flagged:
-        st.caption("Safety timeline")
-        for i, a in enumerate(analyses, start=1):
-            f = a.get("safety_protocol")
-            if f:
-                st.markdown(f"- Message {i}: **{f.get('action')}** — {f.get('flag_type')}")
-
-    # Topics detected this session
-    topics = []
-    for a in analyses:
-        topic = a.get("topic")
-        if topic and topic not in topics:
-            topics.append(topic)
-    if topics:
-        st.caption("Topics detected")
-        st.markdown(" ".join(f"`{t}`" for t in topics))
-
-    _render_profile(patient_profile)
+        txt, color = "→ flat", "#8a93a8"
+    return " ".join(pts), txt, color, True
 
 
-def _render_profile(patient_profile):
-    profile = patient_profile or {}
-    mh = profile.get("medical_history") or []
-    tg = profile.get("therapy_goals") or []
-    if not (mh or tg):
-        return
-    st.caption("Patient profile")
-    if mh:
-        st.markdown("**History:** " + ", ".join(mh))
-    if tg:
-        st.markdown("**Goals:** " + ", ".join(tg))
+def render_dashboard(conversation, patient_profile=None):
+    """Right-column session metrics: current emotion, topic, sentiment trajectory.
+
+    Reads only data already produced per message — no model calls here.
+    """
+    analyses = _assistant_analyses(conversation)
+    emotion, topic = "—", "—"
+    if analyses:
+        latest = analyses[-1]
+        urgency = latest.get("urgency") or {}
+        if urgency.get("label"):
+            emotion = str(urgency["label"]).title()
+        topic = latest.get("topic") or "—"
+
+    points, delta_text, delta_color, has = trajectory(conversation)
+    st.markdown(
+        ui.metrics_panel(emotion, topic, points, delta_text, delta_color, has),
+        unsafe_allow_html=True,
+    )

--- a/explain.py
+++ b/explain.py
@@ -53,43 +53,40 @@ def render_advice(advice_text):
 
 
 def render_why(analysis):
-    """Per-message 'Why this guidance' expander: the signals, retrieved cases,
-    and the exact context sent to the model."""
+    """'Why this guidance' grounding panel: the driving signals, retrieved
+    cases, and the exact context sent to the model — in the cockpit style."""
     import streamlit as st
+    import ui
     if not analysis:
         return
-    with st.expander("Why this guidance"):
-        st.markdown("**Signals that informed this**")
-        rows = []
-        topic, tconf = analysis.get("topic"), analysis.get("topic_confidence")
-        if topic:
-            note = " · weak hint" if isinstance(tconf, (int, float)) and tconf < 0.4 else ""
-            conf = f" · {tconf:.0%} confidence{note}" if isinstance(tconf, (int, float)) else ""
-            rows.append(f"- Topic: `{topic}`{conf}")
-        sentiment, sscore = analysis.get("sentiment"), analysis.get("sentiment_score")
-        if sentiment:
-            score = f" ({sscore:+.2f})" if isinstance(sscore, (int, float)) else ""
-            rows.append(f"- Sentiment: {sentiment}{score}")
-        urgency = analysis.get("urgency") or {}
-        if urgency.get("label"):
-            score = f" ({urgency['score']:.0%})" if isinstance(urgency.get("score"), (int, float)) else ""
-            rows.append(f"- Emotion: {urgency['label']}{score}")
-        sp = analysis.get("safety_protocol")
-        if sp:
-            rows.append(f"- Safety: **{sp.get('action')}** — {sp.get('flag_type')}")
-        st.markdown("\n".join(rows) if rows else "_No signals recorded._")
 
-        examples = analysis.get("historical_examples") or []
-        st.markdown(f"**Similar past cases retrieved ({len(examples)})**")
-        if examples:
-            for ex in examples[:3]:
-                q = (ex.get("questionText") or "")[:200]
-                a = (ex.get("answerText") or "")[:200]
-                st.markdown(f"- *Patient:* {q}\n\n  *Therapist:* {a}")
-        else:
-            st.caption("None retrieved (semantic search returned no matches).")
+    signals = []
+    topic, tconf = analysis.get("topic"), analysis.get("topic_confidence")
+    if topic:
+        conf = f" · {tconf:.0%}" if isinstance(tconf, (int, float)) else ""
+        signals.append(("Topic (BART zero-shot)", f"{topic}{conf}"))
+    sentiment, sscore = analysis.get("sentiment"), analysis.get("sentiment_score")
+    if sentiment:
+        score = f" · {sscore:+.2f}" if isinstance(sscore, (int, float)) else ""
+        signals.append(("Sentiment (RoBERTa)", f"{sentiment}{score}"))
+    urgency = analysis.get("urgency") or {}
+    if urgency.get("label"):
+        score = f" · {urgency['score']:.0%}" if isinstance(urgency.get("score"), (int, float)) else ""
+        signals.append(("Emotion (DistilRoBERTa)", f"{urgency['label']}{score}"))
+    sp = analysis.get("safety_protocol")
+    signals.append(("Crisis screen", f"{sp.get('flag_type')} · {sp.get('action')}" if sp else "clear"))
 
-        context = analysis.get("analysis_context")
-        if context:
-            st.markdown("**Context sent to the model**")
-            st.code(context)
+    cases = []
+    for ex in (analysis.get("historical_examples") or [])[:3]:
+        cases.append({
+            "id": ex.get("questionID") or ex.get("id") or "—",
+            "sim": "",
+            "q": (ex.get("questionText") or "")[:200],
+            "a": (ex.get("answerText") or "")[:200],
+        })
+
+    with st.expander("Why this guidance — grounding"):
+        st.markdown(
+            ui.why_panel(signals, cases, analysis.get("analysis_context") or "(no context assembled)"),
+            unsafe_allow_html=True,
+        )

--- a/patient_overview.py
+++ b/patient_overview.py
@@ -9,6 +9,24 @@ def _fmt_date(value):
         return str(value)[:10]
 
 
+def _days_ago(value):
+    """Best-effort '· Nd ago' suffix from a date/datetime/ISO string."""
+    from datetime import datetime, date
+    try:
+        if hasattr(value, "year") and not isinstance(value, datetime):
+            d = datetime(value.year, value.month, value.day)
+        elif isinstance(value, datetime):
+            d = value
+        else:
+            d = datetime.fromisoformat(str(value)[:19])
+        days = (datetime.now() - d).days
+        if days <= 0:
+            return "today"
+        return f"{days}d ago"
+    except Exception:
+        return ""
+
+
 def build_patient_summary(profile):
     """Compact text summary of the patient record for the LLM prompt."""
     profile = profile or {}
@@ -37,20 +55,21 @@ def build_history_summary(sessions, limit=5):
 
 
 def render_patient_overview(patient_id, profile=None, exclude_session_id=None):
-    """Top patient-context card + collapsible history timeline for the doctor.
+    """Left-column patient context: overview card + session-history timeline.
 
     Reads the profile (passed in to avoid a re-fetch) and the patient's prior
     session logs. ``exclude_session_id`` drops the in-progress session so the
     counts/timeline reflect *prior* context.
     """
     import streamlit as st
-    from patient_profile import get_patient_sessions
+    import ui
 
     profile = profile or {}
     medical_history = profile.get("medical_history") or []
     therapy_goals = profile.get("therapy_goals") or []
 
     try:
+        from patient_profile import get_patient_sessions
         sessions = get_patient_sessions(patient_id)
     except Exception:
         sessions = []
@@ -58,40 +77,26 @@ def render_patient_overview(patient_id, profile=None, exclude_session_id=None):
         sessions = [s for s in sessions if s.get("session_id") != exclude_session_id]
 
     last = sessions[0] if sessions else None
-
-    cols = st.columns([2, 1, 1])
-    cols[0].markdown(f"**Patient** `{patient_id}`")
-    cols[1].metric("Past sessions", len(sessions))
-    cols[2].metric("Last seen", _fmt_date(last.get("created_at")) if last else "—")
-
-    if medical_history:
-        st.markdown("**Clinical history:** " + " · ".join(f"`{x}`" for x in medical_history))
-    if therapy_goals:
-        st.markdown("**Therapy goals:** " + ", ".join(therapy_goals))
-
+    subtitle = "returning patient" if sessions else "new patient"
     if last:
-        bits = []
-        topics = last.get("detected_topics") or []
-        flags = last.get("risk_flags") or []
-        score = last.get("sentiment_score")
-        if topics:
-            bits.append("topics: " + ", ".join(topics))
-        if flags:
-            bits.append("risk flags: " + ", ".join(flags))
-        if isinstance(score, (int, float)):
-            bits.append(f"sentiment {score:+.2f}")
-        if bits:
-            st.caption("Most recent session — " + " · ".join(bits))
-
-    if sessions:
-        with st.expander(f"Session history ({len(sessions)})"):
-            for s in sessions[:20]:
-                date = _fmt_date(s.get("created_at"))
-                topics = ", ".join(s.get("detected_topics") or []) or "—"
-                flags = ", ".join(s.get("risk_flags") or [])
-                flag_txt = f" · risk: {flags}" if flags else ""
-                score = s.get("sentiment_score")
-                score_txt = f" · sentiment {score:+.2f}" if isinstance(score, (int, float)) else ""
-                st.markdown(f"- **{date}** — {topics}{flag_txt}{score_txt}")
+        ago = _days_ago(last.get("created_at"))
+        last_seen = _fmt_date(last.get("created_at")) + (f" · {ago}" if ago else "")
     else:
-        st.caption("No prior sessions on record for this patient.")
+        last_seen = "first session"
+
+    st.markdown(
+        ui.patient_overview_card(patient_id, subtitle, len(sessions),
+                                 medical_history, therapy_goals, last_seen),
+        unsafe_allow_html=True,
+    )
+
+    items = []
+    for s in sessions[:8]:
+        flags = s.get("risk_flags") or []
+        items.append({
+            "date": _fmt_date(s.get("created_at")),
+            "topics": s.get("detected_topics") or [],
+            "score": s.get("sentiment_score"),
+            "flag": flags[0] if flags else None,
+        })
+    st.markdown(ui.history_timeline(items), unsafe_allow_html=True)

--- a/session_assistant.py
+++ b/session_assistant.py
@@ -100,78 +100,36 @@ def generate_session_suggestions(transcript, patient_summary, history_summary,
         return out
 
 
-_CONF_LABEL = {
-    "high": "high confidence",
-    "medium": "medium confidence",
-    "low": "low confidence — treat as a hint",
-}
-
-
 def render_suggestions(data, analysis):
-    """Render the assistant panel: deterministic safety first, then LLM aids."""
+    """Render the cockpit decision-support panel + the grounding ('why') toggle.
+
+    The deterministic crisis banner is rendered separately (above the
+    transcript) by the app; here we show the LLM aids and degraded-state notes.
+    """
     import streamlit as st
+    import ui
     from explain import render_why
 
     data = data or {}
     analysis = analysis or {}
 
-    # 1. Deterministic safety — never depends on the LLM.
-    sp = analysis.get("safety_protocol")
-    if sp:
-        st.error(
-            f"Safety — {sp.get('action')}: {sp.get('flag_type')}. {sp.get('response', '')}"
-        )
+    st.markdown(
+        ui.decision_support(
+            state=data.get("emotional_state"),
+            confidence=data.get("state_confidence"),
+            red_flags=data.get("red_flags") or [],
+            missing=data.get("missing_info") or [],
+            questions=data.get("next_questions") or [],
+            follow_ups=data.get("follow_ups") or [],
+            caveat=data.get("caveat"),
+            error=bool(data.get("_error")),
+            degraded=analysis.get("errors") or [],
+        ),
+        unsafe_allow_html=True,
+    )
 
-    # Surface a degraded run instead of silently showing an empty panel.
-    if data.get("_error"):
-        st.warning(
-            "The assistant could not generate suggestions for this turn (model "
-            "error). The deterministic safety check above still applies."
-        )
-    degraded = analysis.get("errors") or []
-    if degraded:
-        st.caption("⚠️ Limited analysis — unavailable: " + ", ".join(degraded))
-
-    red = data.get("red_flags") or []
-    if red:
-        st.markdown("**Red flags / concerns**")
-        for item in red:
-            st.markdown(f"- {item}")
-
-    missing = data.get("missing_info") or []
-    if missing:
-        st.markdown("**Missing info to clarify**")
-        for item in missing:
-            st.markdown(f"- {item}")
-
-    state = data.get("emotional_state")
-    if state:
-        conf = _CONF_LABEL.get((data.get("state_confidence") or "low"), _CONF_LABEL["low"])
-        st.markdown(f"**Likely state** — {state}")
-        st.caption(conf)
-
-    questions = data.get("next_questions") or []
-    if questions:
-        st.markdown("**Next questions to consider**")
-        for q in questions:
-            st.markdown(f"- {q}")
-
-    follow_ups = data.get("follow_ups") or []
-    if follow_ups:
-        st.markdown("**Follow-up points**")
-        for item in follow_ups:
-            st.markdown(f"- {item}")
-
-    if data.get("caveat"):
-        st.caption(f"Note: {data['caveat']}")
     if data.get("_raw"):
         with st.expander("Raw assistant output (could not parse as JSON)"):
             st.code(data["_raw"])
 
-    if not any(data.get(k) for k in ("red_flags", "missing_info", "emotional_state",
-                                     "next_questions", "follow_ups")) and not sp \
-            and not data.get("_error"):
-        st.caption("No high-value suggestions for this turn.")
-
-    st.caption("Decision support — not a diagnosis. Clinical judgment required.")
     render_why(analysis)

--- a/ui.py
+++ b/ui.py
@@ -1,0 +1,458 @@
+"""Cockpit UI theme + presentational HTML builders.
+
+Pure string builders (no Streamlit import) so the markup can be previewed
+standalone. The Streamlit render_* functions call these and pass the result to
+st.markdown(..., unsafe_allow_html=True). Every builder returns a single-line
+HTML string (no embedded newlines) so Streamlit's markdown pass never treats
+indented lines as a code block.
+"""
+from __future__ import annotations
+import html as _html
+
+# ---- design tokens (ported from the Live Session Cockpit mockup) ----
+ACCENT = "#3563d4"
+ACCENT_SOFT = "rgba(53,99,212,.1)"
+BG = "#eef1f6"
+INK = "#1a2235"
+MUTED = "#8a93a8"
+BORDER = "#dde3ee"
+CRISIS = "#c2362f"
+GREEN = "#2f8f6b"
+MONO = "'IBM Plex Mono',ui-monospace,monospace"
+
+
+def esc(value) -> str:
+    """HTML-escape arbitrary (possibly user-entered) content."""
+    return _html.escape("" if value is None else str(value))
+
+
+def _pre(value) -> str:
+    """Escape and keep the string single-line (newlines -> entities)."""
+    return esc(value).replace("\n", "&#10;")
+
+
+# ---------------------------------------------------------------- global CSS
+def css() -> str:
+    """The global <style> block: fonts, chrome hiding, theming, widgets."""
+    return """
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap');
+
+:root { --accent:#3563d4; --ink:#1a2235; --muted:#8a93a8; --border:#dde3ee; }
+
+.stApp, [data-testid="stAppViewContainer"] { background:#eef1f6; }
+[data-testid="stHeader"] { background:transparent; }
+#MainMenu, footer, [data-testid="stToolbar"] { visibility:hidden; }
+html, body, [class*="st-"], .stMarkdown, button, input, textarea {
+  font-family:'Public Sans',system-ui,-apple-system,sans-serif; color:#1a2235;
+}
+.block-container { padding:1.1rem 1.4rem 7rem; max-width:1560px; }
+[data-testid="stVerticalBlock"] { gap:.7rem; }
+[data-testid="stHorizontalBlock"] { gap:.85rem; }
+hr { margin:.5rem 0; border-color:#dde3ee; }
+
+/* section label */
+.lsa-h { display:flex; align-items:center; gap:8px; margin-bottom:13px; }
+.lsa-h .bar { width:3px; height:13px; border-radius:2px; background:var(--accent); }
+.lsa-h .t { font:600 10.5px/1 'IBM Plex Mono',monospace; letter-spacing:.07em; color:#8a93a8; }
+.lsa-card { background:#fff; border:1px solid #dde3ee; border-radius:11px; padding:16px; }
+
+/* buttons */
+.stButton>button, .stFormSubmitButton>button, [data-testid="stBaseButton-primary"],
+[data-testid="stBaseButton-secondary"] {
+  border-radius:8px; font-weight:600; font-family:inherit; font-size:13.5px;
+  transition:filter .15s ease, background .15s ease; box-shadow:none;
+}
+.stButton>button[kind="primary"], .stFormSubmitButton>button[kind="primary"],
+.stFormSubmitButton>button[kind="primaryFormSubmit"], [data-testid="stBaseButton-primary"],
+[data-testid="stBaseButton-primaryFormSubmit"] {
+  background:#3563d4 !important; color:#fff !important; border:none !important;
+}
+.stButton>button[kind="primary"]:hover, .stFormSubmitButton>button:hover { filter:brightness(1.06); }
+.stButton>button[kind="secondary"], [data-testid="stBaseButton-secondary"] {
+  background:#fff !important; color:#3a4458 !important; border:1px solid #dde3ee !important;
+}
+.stButton>button[kind="secondary"]:hover { border-color:#3563d4 !important; color:#28304a !important; }
+
+/* inputs */
+[data-testid="stTextInput"] input, [data-testid="stTextArea"] textarea,
+[data-baseweb="input"] input, [data-baseweb="textarea"] textarea {
+  border:1px solid #dde3ee !important; border-radius:9px !important; background:#fbfcfe !important;
+  color:#1a2235 !important; font-family:inherit; font-size:13.5px;
+}
+[data-testid="stTextInput"] input:focus, [data-testid="stTextArea"] textarea:focus {
+  border-color:#3563d4 !important; box-shadow:0 0 0 2px rgba(53,99,212,.15) !important;
+}
+[data-baseweb="input"], [data-baseweb="textarea"], [data-baseweb="base-input"] {
+  background:#fbfcfe !important; border-radius:9px !important;
+}
+[data-testid="stWidgetLabel"] p, [data-testid="stWidgetLabel"] label {
+  font:600 10.5px/1 'IBM Plex Mono',monospace !important; letter-spacing:.05em; color:#8a93a8 !important;
+  text-transform:uppercase;
+}
+
+/* radio as a segmented toggle */
+[data-testid="stRadio"] [role="radiogroup"] {
+  flex-direction:row; gap:4px; background:#eef1f6; padding:3px; border-radius:8px;
+  width:max-content;
+}
+[data-testid="stRadio"] [role="radiogroup"] label {
+  margin:0; padding:6px 14px; border-radius:6px; cursor:pointer;
+  font:600 12px/1 'Public Sans',sans-serif; color:#7a849c;
+}
+[data-testid="stRadio"] [role="radiogroup"] label:has(input:checked) { background:#3563d4; color:#fff; }
+[data-testid="stRadio"] [role="radiogroup"] label > div:first-child { display:none; }
+
+/* chat input pinned at bottom */
+[data-testid="stChatInput"] { border-radius:9px; }
+[data-testid="stBottomBlockContainer"] { background:#eef1f6; }
+
+/* expander = light card */
+[data-testid="stExpander"] { border:1px solid #dde3ee; border-radius:11px; background:#fff; }
+[data-testid="stExpander"] summary { font:600 10.5px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; color:#8a93a8; }
+
+/* alerts */
+[data-testid="stAlert"] { border-radius:9px; }
+
+/* scrollbars */
+.lsa-scroll::-webkit-scrollbar { width:9px; }
+.lsa-scroll::-webkit-scrollbar-thumb { background:#d3dae8; border-radius:6px; border:2px solid #fff; }
+.lsa-scroll::-webkit-scrollbar-track { background:transparent; }
+
+@keyframes fadeUp { from { opacity:0; transform:translateY(6px); } to { opacity:1; transform:none; } }
+@keyframes spin { to { transform:rotate(360deg); } }
+@keyframes softpulse { 0%,100% { opacity:1; } 50% { opacity:.45; } }
+@keyframes crisisPulse { 0%,100% { box-shadow:0 0 0 0 rgba(194,54,47,.28); } 50% { box-shadow:0 0 0 5px rgba(194,54,47,0); } }
+</style>
+"""
+
+
+def _h(label: str) -> str:
+    return (f'<div class="lsa-h"><span class="bar"></span>'
+            f'<span class="t">{esc(label)}</span></div>')
+
+
+# --------------------------------------------------------------- launch hero
+def launch_hero() -> str:
+    return (
+        '<div style="display:flex;flex-direction:column;align-items:center;text-align:center;margin:8px 0 22px;">'
+        '<div style="width:46px;height:46px;border-radius:13px;background:#3563d4;display:flex;align-items:center;justify-content:center;">'
+        '<div style="width:19px;height:19px;border:2.6px solid #fff;border-radius:50%;border-right-color:transparent;"></div></div>'
+        '<h1 style="font-weight:700;font-size:27px;letter-spacing:-.025em;margin:16px 0 0;">Live Session Assistant</h1>'
+        f'<div style="font:600 11px/1 {MONO};letter-spacing:.16em;color:#8a93a8;margin-top:9px;">CLINICAL DECISION SUPPORT</div>'
+        '<p style="font-size:14px;line-height:1.6;color:#5e6a82;max-width:460px;margin:14px 0 0;">A real-time co-pilot for '
+        'mental-health sessions. Open a patient to load their history and session context, then get grounded, in-the-moment '
+        'decision support.</p>'
+        '<div style="display:inline-flex;align-items:center;gap:8px;margin-top:16px;padding:7px 13px;border:1px solid #f0d9d6;background:#fdf4f3;border-radius:20px;">'
+        '<span style="width:7px;height:7px;border-radius:50%;background:#c2362f;"></span>'
+        '<span style="font-size:12px;font-weight:600;color:#9c453f;">Decision support — not a diagnosis</span></div></div>'
+    )
+
+
+def launch_footer() -> str:
+    return (
+        '<div style="text-align:center;margin-top:18px;font-size:11.5px;color:#9aa3b6;line-height:1.55;">'
+        f'Access is gated by a shared password when <span style="font-family:{MONO};">APP_PASSWORD</span> is configured. '
+        'Use de-identified patient data only.</div>'
+    )
+
+
+# --------------------------------------------------------------- header bar
+def header_bar(patient_id: str, clock: str, turns: int) -> str:
+    return (
+        '<div style="display:flex;align-items:center;gap:16px;background:#fff;border:1px solid #dde3ee;'
+        'border-radius:11px;padding:11px 18px;margin-bottom:4px;">'
+        '<div style="width:30px;height:30px;border-radius:8px;background:#3563d4;display:flex;align-items:center;justify-content:center;flex:none;">'
+        '<div style="width:13px;height:13px;border:2.2px solid #fff;border-radius:50%;border-right-color:transparent;"></div></div>'
+        '<div style="display:flex;flex-direction:column;line-height:1.1;">'
+        '<span style="font-weight:700;font-size:15px;letter-spacing:-.01em;">Live Session Assistant</span>'
+        f'<span style="font:500 10px/1 {MONO};color:#8a93a8;letter-spacing:.04em;margin-top:3px;">CLINICAL DECISION SUPPORT</span></div>'
+        '<div style="display:flex;align-items:center;gap:8px;padding:5px 11px;background:#f4f6fa;border:1px solid #e3e8f2;border-radius:8px;">'
+        f'<span style="font:500 11px/1 {MONO};color:#8a93a8;">PATIENT</span>'
+        f'<span style="font:600 13px/1 {MONO};color:#1a2235;">{esc(patient_id)}</span>'
+        '<span style="width:6px;height:6px;border-radius:50%;background:#2f8f6b;box-shadow:0 0 0 3px rgba(47,143,107,.16);"></span>'
+        '<span style="font-size:11.5px;font-weight:600;color:#2f8f6b;">Session live</span></div>'
+        '<div style="margin-left:auto;display:flex;align-items:center;gap:16px;">'
+        f'<div style="display:flex;align-items:center;gap:7px;"><span style="font:500 10px/1 {MONO};color:#9aa3b6;">ELAPSED</span>'
+        f'<span style="font:600 14px/1 {MONO};color:#1a2235;">{esc(clock)}</span></div>'
+        f'<div style="display:flex;align-items:center;gap:7px;"><span style="font:500 10px/1 {MONO};color:#9aa3b6;">TURNS</span>'
+        f'<span style="font:600 14px/1 {MONO};color:#1a2235;">{turns}</span></div>'
+        '<div style="display:flex;align-items:center;gap:6px;padding:6px 11px;border:1px solid #f0d9d6;background:#fdf4f3;border-radius:8px;">'
+        '<span style="width:7px;height:7px;border-radius:50%;background:#c2362f;flex:none;"></span>'
+        '<span style="font-size:11.5px;font-weight:600;color:#9c453f;">Not a diagnosis</span></div></div></div>'
+    )
+
+
+# --------------------------------------------------------- patient overview
+def patient_overview_card(patient_id, subtitle, sessions, history, goals, last_seen) -> str:
+    hist = "".join(
+        f'<span style="font:500 11.5px/1 {MONO};background:#f0f3f9;color:#4a5670;padding:5px 8px;border-radius:6px;">{esc(h)}</span>'
+        for h in (history or [])
+    ) or '<span style="font-size:12px;color:#aab2c4;">No history recorded</span>'
+    goal_items = "".join(
+        f'<li style="display:flex;gap:8px;font-size:13px;color:#3a4458;"><span style="color:{ACCENT};">›</span>{esc(g)}</li>'
+        for g in (goals or [])
+    ) or '<li style="font-size:12px;color:#aab2c4;list-style:none;">No goals recorded</li>'
+    return (
+        '<div class="lsa-card">' + _h("PATIENT OVERVIEW") +
+        '<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;">'
+        f'<div><div style="font:600 19px/1 {MONO};">{esc(patient_id)}</div>'
+        f'<div style="font-size:12.5px;color:#647089;margin-top:4px;">{esc(subtitle)}</div></div>'
+        '<div style="text-align:center;background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:7px 12px;">'
+        f'<div style="font:600 17px/1 {MONO};">{sessions}</div>'
+        '<div style="font-size:9.5px;color:#8a93a8;margin-top:3px;letter-spacing:.02em;">SESSIONS</div></div></div>'
+        '<div style="margin-top:15px;"><div style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;margin-bottom:7px;">CLINICAL HISTORY</div>'
+        f'<div style="display:flex;flex-wrap:wrap;gap:6px;">{hist}</div></div>'
+        '<div style="margin-top:14px;"><div style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;margin-bottom:7px;">THERAPY GOALS</div>'
+        f'<ul style="margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:6px;">{goal_items}</ul></div>'
+        '<div style="margin-top:15px;padding-top:13px;border-top:1px dashed #e3e8f2;display:flex;justify-content:space-between;font-size:12px;">'
+        f'<span style="color:#8a93a8;">Last seen</span><span style="font-weight:600;color:#3a4458;font-family:{MONO};">{esc(last_seen)}</span></div></div>'
+    )
+
+
+def history_timeline(items) -> str:
+    if not items:
+        body = '<div style="font-size:12.5px;color:#aab2c4;">No prior sessions on record.</div>'
+    else:
+        rows = []
+        n = len(items)
+        for i, t in enumerate(items):
+            dot = CRISIS if t.get("flag") else (ACCENT if i == 0 else "#c2cad8")
+            line = ("display:none;" if i == n - 1
+                    else "flex:1;width:1.5px;background:#e6eaf2;margin:3px 0;")
+            sc = t.get("score")
+            sc_color = "#647089"
+            if isinstance(sc, (int, float)):
+                sc_color = "#b23a31" if sc < -0.6 else "#b5862f" if sc < -0.3 else "#647089"
+            sc_txt = (f'{sc:+.2f}' if isinstance(sc, (int, float)) else "—")
+            topics = "".join(
+                f'<span style="font:500 10.5px/1 {MONO};background:#eef1f6;color:#647089;padding:3px 6px;border-radius:5px;">{esc(tp)}</span>'
+                for tp in (t.get("topics") or [])
+            )
+            flag = ""
+            if t.get("flag"):
+                flag = ('<div style="display:inline-flex;align-items:center;gap:5px;margin-top:7px;padding:3px 7px;background:#fdeceb;border:1px solid #f3c9c5;border-radius:5px;">'
+                        '<span style="width:5px;height:5px;border-radius:50%;background:#c2362f;"></span>'
+                        f'<span style="font:600 10px/1 {MONO};color:#a8423b;">risk: {esc(t.get("flag"))}</span></div>')
+            rows.append(
+                '<div style="display:grid;grid-template-columns:14px 1fr;gap:11px;">'
+                '<div style="display:flex;flex-direction:column;align-items:center;">'
+                f'<span style="width:10px;height:10px;border-radius:50%;flex:none;margin-top:3px;background:{dot};"></span>'
+                f'<span style="{line}"></span></div>'
+                '<div style="padding-bottom:14px;"><div style="display:flex;align-items:center;justify-content:space-between;gap:6px;">'
+                f'<span style="font:600 12px/1 {MONO};color:#3a4458;">{esc(t.get("date"))}</span>'
+                f'<span style="font:600 11px/1 {MONO};color:{sc_color};">{sc_txt}</span></div>'
+                f'<div style="display:flex;flex-wrap:wrap;gap:5px;margin-top:7px;">{topics}</div>{flag}</div></div>'
+            )
+        body = "".join(rows)
+    return '<div class="lsa-card">' + _h("SESSION HISTORY") + body + '</div>'
+
+
+# ------------------------------------------------------------- crisis banner
+def crisis_banner(action, flag_type, response) -> str:
+    return (
+        '<div style="background:#fbeceb;border:1.5px solid #e9b8b3;border-radius:11px;padding:14px 16px;animation:crisisPulse 2.2s ease-in-out infinite;margin-bottom:4px;">'
+        '<div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">'
+        '<div style="width:26px;height:26px;border-radius:7px;background:#c2362f;color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:15px;flex:none;">!</div>'
+        f'<span style="font-weight:700;font-size:14px;color:#9c2f29;">CRISIS PROTOCOL — {esc(action)}</span>'
+        f'<span style="font:600 11px/1 {MONO};background:#f3d4d1;color:#9c2f29;padding:4px 8px;border-radius:5px;">{esc(flag_type)}</span>'
+        f'<span style="margin-left:auto;font:500 10.5px/1 {MONO};color:#b07a76;">DETERMINISTIC · RULE-BASED · NOT LLM</span></div>'
+        f'<p style="margin:10px 0 0;font-size:13px;line-height:1.55;color:#7a3a35;">{esc(response)}</p></div>'
+    )
+
+
+# ------------------------------------------------------------- transcript
+def transcript(messages, turns, height=420) -> str:
+    bubbles = []
+    for m in messages:
+        is_p = m.get("speaker") == "patient"
+        is_crisis = bool(m.get("crisis"))
+        base = "font-size:13.5px;line-height:1.55;padding:11px 13px;border-radius:10px;max-width:88%;border-top-left-radius:3px;"
+        if not is_p:
+            bub = base + "background:#f4f6fa;border:1px solid #e6eaf2;color:#2a3450;"
+            lab = f"font:600 10px/1 {MONO};letter-spacing:.05em;color:#8a93a8;text-transform:uppercase;"
+        elif is_crisis:
+            bub = base + "background:#fbeceb;border:1px solid #e9b8b3;color:#7a3a35;"
+            lab = f"font:600 10px/1 {MONO};letter-spacing:.05em;color:#c2362f;text-transform:uppercase;"
+        else:
+            bub = base + "background:#eef3fd;border:1px solid #d7e2fa;color:#26365e;"
+            lab = f"font:600 10px/1 {MONO};letter-spacing:.05em;color:{ACCENT};text-transform:uppercase;"
+        chips = "".join(
+            f'<span style="font:500 10.5px/1 {MONO};padding:4px 7px;border-radius:5px;background:{bg};color:{col};letter-spacing:.02em;">{esc(txt)}</span>'
+            for (txt, bg, col) in (m.get("chips") or [])
+        )
+        chips_html = (f'<div style="display:flex;flex-wrap:wrap;gap:6px;">{chips}</div>' if chips else "")
+        pending = ('<div style="display:flex;align-items:center;gap:7px;animation:softpulse 1.1s ease-in-out infinite;">'
+                   '<span style="width:6px;height:6px;border-radius:50%;background:#aab2c4;"></span>'
+                   f'<span style="font:500 11px/1 {MONO};color:#aab2c4;">analyzing turn…</span></div>') if m.get("pending") else ""
+        who = "Patient" if is_p else "Doctor"
+        bubbles.append(
+            '<div style="display:flex;flex-direction:column;gap:7px;animation:fadeUp .3s ease;">'
+            f'<div style="display:flex;align-items:center;gap:8px;"><span style="{lab}">{who}</span>'
+            f'<span style="font:500 10px/1 {MONO};color:#b4bccc;">{esc(m.get("time",""))}</span></div>'
+            f'<div style="{bub}">{esc(m.get("text"))}</div>{chips_html}{pending}</div>'
+        )
+    inner = "".join(bubbles) or '<div style="font-size:13px;color:#aab2c4;text-align:center;margin-top:30px;">No turns logged yet. Use the composer below to begin.</div>'
+    return (
+        '<div class="lsa-card" style="padding:0;">'
+        '<div style="display:flex;align-items:center;gap:8px;padding:14px 18px;border-bottom:1px solid #eef1f6;">'
+        '<span style="width:3px;height:13px;border-radius:2px;background:#3563d4;"></span>'
+        f'<span style="font:600 10.5px/1 {MONO};letter-spacing:.07em;color:#8a93a8;">LIVE TRANSCRIPT</span>'
+        '<span style="font-size:11.5px;color:#aab2c4;">two-channel · doctor &amp; patient</span>'
+        f'<span style="margin-left:auto;font:500 11px/1 {MONO};color:#aab2c4;">{turns} turns</span></div>'
+        f'<div class="lsa-scroll" style="max-height:{height}px;overflow-y:auto;padding:18px;display:flex;flex-direction:column;gap:16px;">{inner}</div></div>'
+    )
+
+
+# ----------------------------------------------------------- analysis pipeline
+def pipeline_panel(stages, running, status_label) -> str:
+    smap = {
+        "pending": ("background:#26314c;color:#5d6b8a;border:1px solid #2c3852;", "color:#6b7793;", ""),
+        "done": ("background:#2f8f6b;color:#fff;border:1px solid #2f8f6b;", "color:#cdd6e8;", "✓"),
+        "alert": ("background:#c2362f;color:#fff;border:1px solid #c2362f;", "color:#f0c4c0;font-weight:600;", "!"),
+        "running": ("background:#6f8fdc;color:#fff;border:1px solid #6f8fdc;", "color:#e6ecf8;font-weight:600;", "•"),
+    }
+    rows = []
+    for st_ in stages:
+        dot, lab, icon = smap.get(st_.get("status"), smap["pending"])
+        rows.append(
+            '<div style="display:flex;align-items:center;gap:10px;padding:5px 0;">'
+            f'<span style="width:18px;height:18px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;font:700 10px/1 {MONO};{dot}">{icon}</span>'
+            f'<span style="font-size:12.5px;{lab}">{esc(st_.get("label"))}</span>'
+            f'<span style="font:500 10px/1 {MONO};color:#5c6885;margin-left:auto;">{esc(st_.get("sub"))}</span></div>'
+        )
+    badge = ("background:#2a3a63;color:#9fb6f0;" if running else "background:#1f4a3a;color:#7fd6b0;")
+    return (
+        '<div style="background:#172033;border:1px solid #172033;border-radius:11px;padding:15px 16px;color:#cdd6e8;">'
+        '<div style="display:flex;align-items:center;gap:8px;margin-bottom:13px;">'
+        '<span style="width:3px;height:13px;border-radius:2px;background:#6f8fdc;"></span>'
+        f'<span style="font:600 10.5px/1 {MONO};letter-spacing:.07em;color:#8b97b4;">ANALYSIS PIPELINE</span>'
+        f'<span style="margin-left:auto;font:600 9.5px/1 {MONO};letter-spacing:.06em;padding:3px 7px;border-radius:5px;{badge}">{esc(status_label)}</span></div>'
+        f'<div style="display:flex;flex-direction:column;gap:3px;">{"".join(rows)}</div></div>'
+    )
+
+
+# ----------------------------------------------------------- decision support
+_CONF = {
+    "high": ("#e8f5ef", "#2f8f6b", "high confidence"),
+    "medium": ("#fbf6e9", "#b5862f", "medium confidence"),
+    "low": ("#eef1f6", "#8a93a8", "low — treat as a hint"),
+}
+
+
+def _list_block(items, *, bg, border, color, marker, marker_color):
+    rows = "".join(
+        f'<div style="display:flex;gap:8px;background:{bg};border:1px solid {border};border-radius:8px;padding:9px 11px;font-size:12.5px;line-height:1.45;color:{color};">'
+        f'<span style="color:{marker_color};font-weight:700;flex:none;">{marker}</span>{esc(it)}</div>'
+        for it in items
+    )
+    return f'<div style="display:flex;flex-direction:column;gap:7px;">{rows}</div>'
+
+
+def decision_support(state, confidence, red_flags, missing, questions,
+                     follow_ups, caveat, error=False, degraded=None) -> str:
+    parts = ['<div class="lsa-card">' + _h("DECISION SUPPORT")]
+
+    if error:
+        parts.append('<div style="background:#fdf4f3;border:1px solid #f0d9d6;border-radius:9px;padding:10px 12px;font-size:12.5px;color:#9c453f;margin-bottom:12px;">'
+                     'The assistant could not generate suggestions for this turn (model error). The deterministic safety check still applies.</div>')
+    if degraded:
+        parts.append(f'<div style="font:500 11px/1.4 {MONO};color:#b5862f;margin-bottom:11px;">⚠ Limited analysis — unavailable: {esc(", ".join(degraded))}</div>')
+
+    if state:
+        bg, col, lab = _CONF.get((confidence or "low"), _CONF["low"])
+        parts.append(
+            '<div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:9px;padding:12px;margin-bottom:13px;">'
+            '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px;">'
+            '<span style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;">LIKELY EMOTIONAL STATE</span>'
+            f'<span style="font:600 9.5px/1 {MONO};letter-spacing:.03em;padding:4px 7px;border-radius:5px;background:{bg};color:{col};">{lab}</span></div>'
+            f'<div style="font-size:14px;font-weight:600;color:#28304a;line-height:1.4;">{esc(state)}</div></div>'
+        )
+    if red_flags:
+        parts.append('<div style="margin-bottom:14px;"><div style="display:flex;align-items:center;gap:7px;margin-bottom:8px;">'
+                     '<span style="width:6px;height:6px;border-radius:2px;background:#c2362f;"></span>'
+                     '<span style="font-size:11px;font-weight:700;color:#a8423b;letter-spacing:.02em;">RED FLAGS / CONCERNS</span></div>'
+                     + _list_block(red_flags, bg="#fdeceb", border="#f3c9c5", color="#8a3833", marker="›", marker_color="#c2362f") + '</div>')
+    if missing:
+        parts.append('<div style="margin-bottom:14px;"><div style="font-size:11px;font-weight:700;color:#9a7a2a;letter-spacing:.02em;margin-bottom:8px;">MISSING INFO TO CLARIFY</div>'
+                     + _list_block(missing, bg="#fbf6e9", border="#efe1c0", color="#7a6420", marker="?", marker_color="#b5862f") + '</div>')
+    if questions:
+        parts.append('<div style="margin-bottom:14px;"><div style="font-size:11px;font-weight:700;color:#3052b8;letter-spacing:.02em;margin-bottom:8px;">NEXT QUESTIONS TO CONSIDER</div>'
+                     + _list_block(questions, bg="#eef3fd", border="#d7e2fa", color="#2f3e63", marker="→", marker_color=ACCENT) + '</div>')
+    if follow_ups:
+        items = "".join(
+            f'<div style="display:flex;gap:8px;font-size:12.5px;line-height:1.45;color:#4a5670;"><span style="color:#aab2c4;">•</span>{esc(f)}</div>'
+            for f in follow_ups
+        )
+        parts.append('<div style="margin-bottom:6px;"><div style="font-size:11px;font-weight:700;color:#647089;letter-spacing:.02em;margin-bottom:8px;">FOLLOW-UP POINTS</div>'
+                     f'<div style="display:flex;flex-direction:column;gap:6px;">{items}</div></div>')
+    if caveat:
+        parts.append(f'<div style="margin-top:10px;font-size:11.5px;font-style:italic;color:#9aa3b6;line-height:1.45;">Note: {esc(caveat)}</div>')
+
+    if not any([state, red_flags, missing, questions, follow_ups]) and not error:
+        parts.append('<div style="font-size:12.5px;color:#9aa3b6;">No high-value suggestions for this turn.</div>')
+
+    parts.append('<div style="margin-top:14px;padding-top:12px;border-top:1px dashed #e3e8f2;font-size:11px;color:#9aa3b6;line-height:1.45;">'
+                 'Every item is grounded in the patient record, the live transcript, and retrieved cases. The assistant suggests — it never decides. Clinical judgment required.</div>')
+    parts.append('</div>')
+    return "".join(parts)
+
+
+def why_panel(signals, cases, context) -> str:
+    sig = "".join(
+        '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;font-size:12px;">'
+        f'<span style="color:#647089;">{esc(k)}</span>'
+        f'<span style="font:600 11.5px/1 {MONO};color:#3a4458;">{esc(v)}</span></div>'
+        for (k, v) in (signals or [])
+    )
+    cases_html = ""
+    if cases:
+        def _case(c):
+            sim = c.get("sim")
+            badge = (f'<span style="font:600 10px/1 {MONO};color:#2f8f6b;">{esc(sim)} match</span>'
+                     if sim else '<span style="font:600 9.5px/1 ' + MONO + ';color:#aab2c4;">retrieved</span>')
+            return (
+                '<div style="background:#fff;border:1px solid #e6eaf2;border-radius:7px;padding:9px 10px;">'
+                '<div style="display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:5px;">'
+                f'<span style="font:600 9.5px/1 {MONO};color:#aab2c4;letter-spacing:.04em;">CORPUS · {esc(c.get("id"))}</span>{badge}</div>'
+                f'<div style="font-size:11.5px;color:#3a4458;line-height:1.4;margin-bottom:4px;">“{esc(c.get("q"))}”</div>'
+                f'<div style="font-size:11px;color:#8a93a8;line-height:1.4;">{esc(c.get("a"))}</div></div>'
+            )
+        cards = "".join(_case(c) for c in cases)
+        cases_html = ('<div style="font-size:10px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin:0 0 9px;">RETRIEVED SIMILAR CASES (RAG)</div>'
+                      f'<div style="display:flex;flex-direction:column;gap:8px;margin-bottom:13px;">{cards}</div>')
+    return (
+        '<div style="background:#f7f9fc;border:1px solid #e6eaf2;border-radius:9px;padding:13px;">'
+        '<div style="font-size:10px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:9px;">DRIVING SIGNALS</div>'
+        f'<div style="display:flex;flex-direction:column;gap:6px;margin-bottom:13px;">{sig}</div>{cases_html}'
+        '<div style="font-size:10px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:7px;">CONTEXT SENT TO MODEL</div>'
+        f'<pre style="margin:0;background:#172033;color:#aeb9d4;border-radius:7px;padding:10px;font:500 10.5px/1.5 {MONO};white-space:pre-wrap;word-break:break-word;">{_pre(context)}</pre></div>'
+    )
+
+
+# ---------------------------------------------------------------- metrics
+def metrics_panel(emotion, topic, traj_points, delta_text, delta_color, has_traj) -> str:
+    spark = ""
+    if has_traj:
+        spark = (
+            '<div style="background:#f7f9fc;border:1px solid #e6eaf2;border-radius:8px;padding:10px 6px 4px;">'
+            '<svg viewBox="0 0 240 60" preserveAspectRatio="none" style="width:100%;height:56px;display:block;">'
+            '<line x1="0" y1="30" x2="240" y2="30" stroke="#d9e0ec" stroke-width="1" stroke-dasharray="3 3"></line>'
+            f'<polyline points="{traj_points}" fill="none" stroke="{ACCENT}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"></polyline></svg>'
+            f'<div style="display:flex;justify-content:space-between;font:500 9px/1 {MONO};color:#aab2c4;padding:0 4px;"><span>turn 1</span><span>now</span></div></div>'
+        )
+    else:
+        spark = '<div style="font-size:11.5px;color:#aab2c4;">Trajectory appears after two analyzed turns.</div>'
+    return (
+        '<div class="lsa-card">' + _h("SESSION METRICS") +
+        '<div style="display:grid;grid-template-columns:1fr 1fr;gap:9px;margin-bottom:14px;">'
+        '<div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:10px;">'
+        '<div style="font-size:9.5px;color:#8a93a8;letter-spacing:.03em;margin-bottom:5px;">EMOTION</div>'
+        f'<div style="font-weight:600;font-size:14px;color:#28304a;">{esc(emotion)}</div></div>'
+        '<div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:10px;">'
+        '<div style="font-size:9.5px;color:#8a93a8;letter-spacing:.03em;margin-bottom:5px;">TOPIC</div>'
+        f'<div style="font-weight:600;font-size:14px;color:#28304a;">{esc(topic)}</div></div></div>'
+        '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:9px;">'
+        '<span style="font-size:11px;color:#8a93a8;">Sentiment trajectory</span>'
+        f'<span style="font:600 11px/1 {MONO};color:{delta_color};">{esc(delta_text)}</span></div>{spark}</div>'
+    )


### PR DESCRIPTION
## Summary

Replaces the two-column Streamlit layout with the **Live Session Cockpit** design: a fixed header over a `316 / flexible / 404` three-column grid, themed with Public Sans / IBM Plex Mono and a `#3563d4` accent. Pure-HTML builders live in a new `ui.py` (no Streamlit import — unit-previewable); `app_chat.py` orchestrates and the render modules delegate to it.

### Layout
- **Header** — logo, patient pill (`Session live`), elapsed clock, turn count, "Not a diagnosis" badge.
- **Left** — patient overview card + session-history timeline (`patient_overview.py`) and the clinician-notes textarea.
- **Center** — deterministic crisis banner (above the transcript), the two-channel live transcript with per-turn **emotion / sentiment / topic chips** and crisis styling, and the speaker toggle + composer.
- **Right** — dark **analysis-pipeline** panel reflecting each stage's real outcome (crisis = alert, failed stage = muted, `DEGRADED`/`COMPLETE` label), the **decision-support** card (`session_assistant.render_suggestions` → `ui.decision_support`), the grounding **"why"** panel (`explain.render_why` → `ui.why_panel`), and the **session-metrics** card with the sentiment-trajectory sparkline (`dashboard.py`).
- **Landing** rebuilt as the launch screen (hero, patient-ID, demo personas).
- **End-of-session report** moved into an `st.dialog` modal that carries the accumulated risk flags / topics.
- `.streamlit/config.toml` retheme to the cockpit palette.

The hardening behaviour from #23 is preserved and now surfaces in the cockpit: degraded-analysis notes, model-error and persistence warnings render in the panels; the pipeline panel visualises which stages degraded.

## Test plan
- `pytest` → **26 passed, 1 skipped** (unchanged).
- All cockpit modules `py_compile`; every `ui.py` builder smoke-tested standalone (no Streamlit needed).
- Stubbed Streamlit + heavy deps and **executed `landing_page()` and `chat_page()`** end-to-end (empty session + a full crisis turn with degraded retrieval) — no wiring errors; pipeline correctly reports `alert`/`pending` per stage.

> Note: a live Streamlit render was not possible in the dev sandbox (needs torch/transformers/pymongo + Groq/Pinecone/Mongo). The builders mirror the provided mockup markup exactly; please sanity-check visually with `streamlit run app_chat.py`.