### PR TITLE
Embed the Live Session Cockpit prototype, wired to the real backend

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -3,8 +3,8 @@ runOnSave = false
 
 [theme]
 base = "light"
-primaryColor = "#2E7D6B"
-backgroundColor = "#FFFFFF"
-secondaryBackgroundColor = "#F4F7F6"
-textColor = "#1F2933"
+primaryColor = "#3563d4"
+backgroundColor = "#eef1f6"
+secondaryBackgroundColor = "#ffffff"
+textColor = "#1a2235"
 font = "sans serif"

--- a/app_chat.py
+++ b/app_chat.py
@@ -3,6 +3,8 @@ import hmac
 import streamlit as st
 import logging
 import uuid
+from datetime import datetime
+import ui
 from logging_config import setup_logging
 from unified_guidance import analyze_message
 from archiver import archive_conversation, archive_session
@@ -63,16 +65,8 @@ st.set_page_config(
     initial_sidebar_state="collapsed"
 )
 
-# Hide default Streamlit chrome and apply light layout polish.
-st.markdown("""
-<style>
-#MainMenu, footer, header {visibility: hidden;}
-.block-container {padding-top: 2.5rem; max-width: 1200px;}
-[data-testid="stChatMessage"] {padding: 0.2rem 0;}
-[data-testid="stMetric"] {background: var(--secondary-background-color, #F4F7F6);
-    border-radius: 10px; padding: 10px 14px;}
-</style>
-""", unsafe_allow_html=True)
+# Cockpit theme: hide default chrome, fonts, widget styling, segmented toggle.
+st.markdown(ui.css(), unsafe_allow_html=True)
 
 # Initialize session state
 if "page" not in st.session_state:
@@ -128,7 +122,7 @@ SUGGESTED_PROMPTS = [
 _SESSION_KEYS = (
     "conversation", "conversation_model", "patient_profile", "session_risk_flags",
     "session_topics", "session_suggestions", "latest_suggestions", "latest_analysis",
-    "history_summary", "doctor_notes_input", "demo_mode",
+    "history_summary", "doctor_notes_input", "demo_mode", "session_started", "last_report",
 )
 
 
@@ -141,7 +135,9 @@ def _new_live_session(patient_id):
     st.session_state.session_risk_flags = []
     st.session_state.session_topics = []
     st.session_state.session_suggestions = []
-    for k in ("latest_suggestions", "latest_analysis", "history_summary", "doctor_notes_input"):
+    st.session_state.session_started = datetime.now()
+    for k in ("latest_suggestions", "latest_analysis", "history_summary",
+              "doctor_notes_input", "last_report"):
         st.session_state.pop(k, None)
 
 
@@ -316,7 +312,10 @@ def handle_turn(content, speaker):
     """Append a transcript turn. Patient turns trigger the assistant; doctor
     turns are logged as context only."""
     is_patient = speaker == "patient"
-    st.session_state.conversation.append({"speaker": speaker, "content": content})
+    st.session_state.conversation.append({
+        "speaker": speaker, "content": content,
+        "time": datetime.now().strftime("%H:%M"),
+    })
     st.session_state.conversation_model.add_message(
         Message(content=content, is_user=is_patient, speaker=speaker)
     )
@@ -326,188 +325,282 @@ def handle_turn(content, speaker):
     st.rerun()
 
 
-# Landing Page
+# --------------------------------------------------------------- cockpit glue
+def _elapsed_clock():
+    """mm:ss since the session started (updates each rerun, not live-ticking)."""
+    start = st.session_state.get("session_started")
+    if not start:
+        return "00:00"
+    secs = max(0, int((datetime.now() - start).total_seconds()))
+    return f"{secs // 60:02d}:{secs % 60:02d}"
+
+
+# Per-message transcript chips: (text, background, color).
+_AMBER = ("#fbf3e4", "#8a6a1f")
+_TOPIC = ("#eaf0fd", "#3052b8")
+
+
+def _transcript_messages():
+    """Adapt the live conversation into ui.transcript's message dicts, attaching
+    emotion/sentiment/topic chips and the crisis flag to analyzed patient turns."""
+    out = []
+    for m in st.session_state.conversation:
+        speaker = m.get("speaker") or "patient"
+        entry = {"speaker": speaker, "text": m.get("content"),
+                 "time": m.get("time", ""), "chips": [], "crisis": False}
+        a = m.get("analysis")
+        if a and speaker == "patient":
+            chips = []
+            urgency = a.get("urgency") or {}
+            if urgency.get("label"):
+                score = urgency.get("score")
+                label = str(urgency["label"]).title()
+                txt = f"{label} · {score:.0%}" if isinstance(score, (int, float)) else label
+                chips.append((txt, *_AMBER))
+            ss = a.get("sentiment_score")
+            if isinstance(ss, (int, float)):
+                bg, col = (("#fdeceb", "#b23a31") if ss < 0
+                           else ("#e8f5ef", "#2f8f6b") if ss > 0 else ("#eef1f6", "#647089"))
+                chips.append((f"{ss:+.2f}", bg, col))
+            if a.get("topic"):
+                chips.append((str(a["topic"]), *_TOPIC))
+            entry["chips"] = chips
+            entry["crisis"] = bool(a.get("safety_protocol"))
+        out.append(entry)
+    return out
+
+
+_PIPELINE_DEFS = [
+    ("Crisis screen", "regex · deterministic"),
+    ("Emotion / urgency", "DistilRoBERTa"),
+    ("Sentiment", "RoBERTa 3-class"),
+    ("Topic", "BART zero-shot"),
+    ("Semantic retrieval", "MiniLM · Pinecone"),
+    ("Generating guidance", "Groq · llama-3.3-70b"),
+]
+
+
+def _pipeline_stages():
+    """Build the analysis-pipeline panel state from the latest turn's outcome."""
+    a = st.session_state.get("latest_analysis") or {}
+    sug = st.session_state.get("latest_suggestions") or {}
+    if not a.get("analysis_context") and not a.get("safety_protocol") and not st.session_state.conversation:
+        return ([{"label": l, "sub": s, "status": "pending"} for l, s in _PIPELINE_DEFS],
+                False, "IDLE")
+    errors = a.get("errors") or []
+    sp = a.get("safety_protocol")
+    status_for = lambda key: "pending" if key in errors else "done"
+    stages = [
+        {"label": "Crisis screen", "sub": "regex · deterministic",
+         "status": "alert" if sp else "done"},
+        {"label": "Emotion / urgency", "sub": "DistilRoBERTa", "status": status_for("urgency")},
+        {"label": "Sentiment", "sub": "RoBERTa 3-class", "status": status_for("analysis")},
+        {"label": "Topic", "sub": "BART zero-shot", "status": status_for("analysis")},
+        {"label": "Semantic retrieval", "sub": "MiniLM · Pinecone", "status": status_for("retrieval")},
+        {"label": "Generating guidance", "sub": "Groq · llama-3.3-70b",
+         "status": "alert" if sug.get("_error") else "done"},
+    ]
+    degraded = bool(errors) or bool(sug.get("_error"))
+    return stages, False, ("DEGRADED" if degraded else "COMPLETE")
+
+
+def _open_session(patient_id, medical_history, therapy_goals):
+    """Load/create the patient profile and switch to the live session."""
+    try:
+        profile = get_patient_profile(patient_id)
+        if profile is None:
+            profile = create_patient_profile(
+                patient_id, medical_history=medical_history, therapy_goals=therapy_goals,
+            )
+        elif (medical_history and not profile.medical_history) or (
+            therapy_goals and not profile.therapy_goals
+        ):
+            profile = update_patient_fields(
+                patient_id,
+                medical_history=medical_history or profile.medical_history,
+                therapy_goals=therapy_goals or profile.therapy_goals,
+            )
+    except Exception:
+        logger.exception("Failed to load or create patient profile")
+        st.error("Could not load the patient profile. Please try again later.")
+        return
+
+    st.session_state.demo_mode = False
+    st.session_state.patient_profile = profile.dict()
+    _new_live_session(patient_id)
+    st.session_state.page = "chat"
+    st.rerun()
+
+
+# Landing / launch screen
 def landing_page():
-    st.markdown("""
-        <div style='text-align:center; padding:16px;'>
-            <h1>🩺 Live Session Assistant</h1>
-            <p style='font-size:17px;'>
-                A real-time co-pilot for mental-health clinicians. Enter a patient ID to load their
-                history, then log the live session — the assistant suggests the patient's likely state,
-                next questions to ask, follow-ups, and red flags.
-                <br><br><b>Decision support only — not a diagnosis. The clinician stays in control.</b>
-            </p>
-        </div>
-        """, unsafe_allow_html=True)
+    _, mid, _ = st.columns([1, 2.2, 1])
+    with mid:
+        st.markdown(ui.launch_hero(), unsafe_allow_html=True)
 
-    patient_id = st.text_input("Patient ID", key="patient_id_input")
-    medical_history_input = st.text_area(
-        "Clinical history (optional, one item per line)", key="medical_history_input"
-    )
-    therapy_goals_input = st.text_area(
-        "Therapy goals (optional, one item per line)", key="therapy_goals_input"
-    )
+        patient_id = st.text_input("Patient ID", key="patient_id_input", placeholder="e.g. PT-0042")
+        with st.expander("Add clinical context (optional)"):
+            medical_history_input = st.text_area(
+                "Clinical history (one item per line)", key="medical_history_input"
+            )
+            therapy_goals_input = st.text_area(
+                "Therapy goals (one item per line)", key="therapy_goals_input"
+            )
 
-    if st.button("Open session"):
-        patient_id = patient_id.strip()
-        if not patient_id:
-            st.error("Please enter a patient ID before starting.")
-            return
-
-        medical_history = _parse_lines(medical_history_input)
-        therapy_goals = _parse_lines(therapy_goals_input)
-
-        try:
-            profile = get_patient_profile(patient_id)
-            if profile is None:
-                profile = create_patient_profile(
-                    patient_id, medical_history=medical_history, therapy_goals=therapy_goals,
-                )
-            elif (medical_history and not profile.medical_history) or (
-                therapy_goals and not profile.therapy_goals
-            ):
-                profile = update_patient_fields(
+        if st.button("Open session", type="primary", use_container_width=True):
+            patient_id = (patient_id or "").strip()
+            if not patient_id:
+                st.error("Please enter a patient ID before starting.")
+            else:
+                _open_session(
                     patient_id,
-                    medical_history=medical_history or profile.medical_history,
-                    therapy_goals=therapy_goals or profile.therapy_goals,
+                    _parse_lines(st.session_state.get("medical_history_input")),
+                    _parse_lines(st.session_state.get("therapy_goals_input")),
                 )
-        except Exception:
-            logger.exception("Failed to load or create patient profile")
-            st.error("Could not load the patient profile. Please try again later.")
-            return
 
-        st.session_state.demo_mode = False
-        st.session_state.patient_profile = profile.dict()
-        _new_live_session(patient_id)
-        st.session_state.page = "chat"
-        st.rerun()
+        st.markdown(
+            f'<div style="display:flex;align-items:center;gap:12px;margin:18px 0 12px;">'
+            f'<span style="flex:1;height:1px;background:#dde3ee;"></span>'
+            f'<span style="font:500 10.5px/1 {ui.MONO};color:#aab2c4;letter-spacing:.04em;">'
+            f'OR START WITH A DEMO PERSONA</span>'
+            f'<span style="flex:1;height:1px;background:#dde3ee;"></span></div>',
+            unsafe_allow_html=True,
+        )
+        demo_cols = st.columns(len(DEMO_PERSONAS))
+        for i, (name, persona) in enumerate(DEMO_PERSONAS.items()):
+            if demo_cols[i].button(name, key=f"demo_persona_{i}", use_container_width=True):
+                start_demo(persona)
 
-    st.divider()
-    st.markdown("#### Or try a live demo")
-    st.caption("Explore the assistant with a sample patient — no patient ID or setup needed.")
-    demo_cols = st.columns(len(DEMO_PERSONAS))
-    for i, (name, persona) in enumerate(DEMO_PERSONAS.items()):
-        if demo_cols[i].button(name, key=f"demo_persona_{i}", use_container_width=True):
-            start_demo(persona)
+        st.markdown(ui.launch_footer(), unsafe_allow_html=True)
 
 
-# Chat Page
+def _generate_report():
+    """Compute the end-of-session report from accumulated session signals."""
+    conv = st.session_state.conversation
+    # Classify over the patient's own turns (doctor questions skew topic/sentiment).
+    patient_text = "\n".join(m["content"] for m in conv if m.get("speaker") == "patient") \
+        or "\n".join(m["content"] for m in conv)
+    classifier = load_topic_classifier()
+    predicted_topic, topic_confidence = predict_topic(patient_text, classifier)
+    sentiment, sentiment_score = analyze_sentiment(patient_text)
+
+    risk_flags = st.session_state.get("session_risk_flags") or []
+    topics = st.session_state.get("session_topics") or []
+    notes = st.session_state.get("doctor_notes_input", "")
+    prompt = (
+        f"Patient Session Report:\n"
+        f"Topic: {predicted_topic} (Confidence: {topic_confidence:.2f})\n"
+        f"Topics observed this session: {', '.join(topics) or 'n/a'}\n"
+        f"Overall Sentiment: {sentiment} (Score: {sentiment_score})\n"
+        f"Risk flags raised this session: {', '.join(risk_flags) or 'none'}\n"
+        f"Clinician notes: {notes or '(none)'}\n\n"
+        "Provide a structured clinician-facing session summary with sections:\n"
+        "1. **Presentation & key themes**\n"
+        "2. **Areas of concern / risk** — explicitly address every risk flag listed above.\n"
+        "3. **Suggested follow-up** (for the clinician to consider; not prescriptive).\n"
+        "Use clear headings and bullet points. Do not diagnose or prescribe."
+    )
+    recommendations_obj = generate_advice(prompt)
+    recommendations = (recommendations_obj if isinstance(recommendations_obj, str)
+                       else str(recommendations_obj))
+    return {
+        "topic": predicted_topic, "topic_conf": topic_confidence,
+        "sentiment": sentiment, "score": sentiment_score,
+        "risk_flags": risk_flags, "topics": topics, "recommendations": recommendations,
+    }
+
+
+@st.dialog("End-of-session report", width="large")
+def _report_dialog():
+    pid = st.session_state.conversation_model.patient_id
+    st.caption(f"{pid} · {_elapsed_clock()} · {len(st.session_state.conversation)} turns logged")
+    if st.button("Generate / regenerate", type="primary") or "last_report" not in st.session_state:
+        with st.spinner("Generating the session report…"):
+            try:
+                st.session_state["last_report"] = _generate_report()
+            except Exception:
+                logger.exception("Error generating report")
+                st.session_state.pop("last_report", None)
+                st.error("An error occurred while generating the report. Please try again later.")
+                return
+    rep = st.session_state.get("last_report")
+    if not rep:
+        return
+    if rep["risk_flags"]:
+        st.error("**Risk flags raised this session:** " + ", ".join(rep["risk_flags"]))
+    st.markdown(f"**Predicted topic:** {rep['topic']} · **Confidence:** {rep['topic_conf']:.2f}")
+    st.markdown(f"**Overall sentiment:** {rep['sentiment']} ({rep['score']})")
+    if rep["topics"]:
+        st.caption("Topics detected: " + ", ".join(rep["topics"]))
+    st.markdown(rep["recommendations"])
+    st.caption("Decision support generated from session signals — not a diagnosis or medical "
+               "record. Review, edit, and sign before filing.")
+
+
+# Chat / cockpit page
 def chat_page():
-    st.title("🩺 Live Session Assistant")
-    st.caption("Decision support for the clinician — not a diagnosis. You stay in control.")
-
     # Surface a persistence failure from the previous turn (set just before the
     # rerun that brought us here, so it could not be shown inline).
     if st.session_state.pop("persist_error", False):
         st.warning("⚠️ The last turn may not have been saved to the database. "
                    "Check the patient profile exists and the database is reachable.")
 
-    ctrl_left, ctrl_right = st.columns([3, 1])
+    pid = st.session_state.conversation_model.patient_id
+    sid = st.session_state.conversation_model.session_id
+    conv = st.session_state.conversation
+    profile = st.session_state.get("patient_profile") or {}
+    latest_analysis = st.session_state.get("latest_analysis") or {}
+    latest_suggestions = st.session_state.get("latest_suggestions") or {}
+
+    st.markdown(ui.header_bar(pid, _elapsed_clock(), len(conv)), unsafe_allow_html=True)
+
+    c_info, c_report, c_new = st.columns([6, 1.6, 1.2])
     if st.session_state.get("demo_mode"):
-        ctrl_left.caption("Demo mode — sample patient, nothing is saved.")
-    if ctrl_right.button("New session", use_container_width=True):
+        c_info.caption("Demo mode — sample patient, nothing is saved.")
+    if c_report.button("End session & report", type="primary", use_container_width=True):
+        _report_dialog()
+    if c_new.button("New session", use_container_width=True):
         reset_session()
 
-    render_patient_overview(
-        st.session_state.conversation_model.patient_id,
-        st.session_state.get("patient_profile") or {},
-        exclude_session_id=st.session_state.conversation_model.session_id,
-    )
-    st.divider()
+    left, center, right = st.columns([316, 480, 404], gap="medium")
 
-    col_chat, col_dash = st.columns([1.3, 1], gap="large")
+    # LEFT — patient context + clinician notes
+    with left:
+        render_patient_overview(pid, profile, exclude_session_id=sid)
+        st.markdown('<div class="lsa-h" style="margin-top:4px;"><span class="bar"></span>'
+                    '<span class="t">CLINICIAN NOTES</span></div>', unsafe_allow_html=True)
+        st.text_area("Clinician notes", key="doctor_notes_input", height=110,
+                     label_visibility="collapsed",
+                     placeholder="Private notes for this session — saved with the session…")
 
-    with col_chat:
-        st.markdown("##### Live transcript")
-        for msg in st.session_state.conversation:
-            speaker = msg.get("speaker") or ("patient" if msg.get("role") == "user" else "doctor")
-            avatar = "🩺" if speaker == "doctor" else "🧑"
-            with st.chat_message(speaker, avatar=avatar):
-                st.markdown(f"**{speaker.capitalize()}:** {msg['content']}")
+    # CENTER — crisis banner + transcript + composer
+    with center:
+        sp = latest_analysis.get("safety_protocol")
+        if sp:
+            st.markdown(ui.crisis_banner(sp.get("action"), sp.get("flag_type"), sp.get("response")),
+                        unsafe_allow_html=True)
+        st.markdown(ui.transcript(_transcript_messages(), len(conv)), unsafe_allow_html=True)
 
+        speaker_label = st.radio("Log turn as", ["Patient", "Doctor"], horizontal=True,
+                                 key="speaker_select", label_visibility="collapsed")
         if st.session_state.get("demo_mode"):
             st.caption("Quick demo patient turns")
             prompt_cols = st.columns(len(SUGGESTED_PROMPTS))
-            for i, prompt in enumerate(SUGGESTED_PROMPTS):
-                if prompt_cols[i].button(prompt["label"], key=f"suggested_{i}", use_container_width=True):
-                    handle_turn(prompt["text"], "patient")
+            for i, p in enumerate(SUGGESTED_PROMPTS):
+                if prompt_cols[i].button(p["label"], key=f"suggested_{i}", use_container_width=True):
+                    handle_turn(p["text"], "patient")
 
-    with col_dash:
-        st.markdown("##### Session assistant")
-        render_suggestions(
-            st.session_state.get("latest_suggestions") or {},
-            st.session_state.get("latest_analysis") or {},
-        )
-        with st.expander("Session metrics", expanded=False):
-            render_dashboard(st.session_state.conversation, st.session_state.get("patient_profile") or {})
+    # RIGHT — analysis pipeline + decision support + session metrics
+    with right:
+        stages, running, status_label = _pipeline_stages()
+        st.markdown(ui.pipeline_panel(stages, running, status_label), unsafe_allow_html=True)
+        render_suggestions(latest_suggestions, latest_analysis)
+        render_dashboard(conv, profile)
 
-        st.text_area("Doctor notes", key="doctor_notes_input", height=100,
-                     placeholder="Your observations, overrides, plan…")
-
-        audit = st.session_state.get("session_suggestions") or []
-        if audit:
-            with st.expander(f"Assistant audit trail ({len(audit)})"):
-                for i, entry in enumerate(audit, 1):
-                    s = entry.get("suggestions") or {}
-                    st.markdown(f"**Turn {i}** — _{(entry.get('turn') or '')[:60]}_")
-                    if s.get("emotional_state"):
-                        st.caption(f"state: {s['emotional_state']}")
-                    if s.get("next_questions"):
-                        st.caption("asked to consider: " + " | ".join(s["next_questions"][:3]))
-                    if entry.get("safety"):
-                        st.caption(f"safety: {entry['safety'].get('flag_type')}")
-
-    # Two-channel input: choose the speaker, then log the turn.
-    speaker_label = st.radio("Log turn as", ["Patient", "Doctor"], horizontal=True, key="speaker_select")
+    # Pinned two-channel input.
     turn = st.chat_input(f"Log what the {speaker_label.lower()} said…")
     if turn:
         handle_turn(turn, "patient" if speaker_label == "Patient" else "doctor")
-
-    with st.expander("Generate end-of-session report"):
-        if st.button("Generate report", key="exit_button"):
-            with st.spinner("Generating the session report…"):
-                try:
-                    # Classify over the patient's own turns (the doctor's
-                    # questions would skew topic/sentiment).
-                    patient_text = "\n".join(
-                        m["content"] for m in st.session_state.conversation
-                        if m.get("speaker") == "patient"
-                    ) or "\n".join(m["content"] for m in st.session_state.conversation)
-                    classifier = load_topic_classifier()
-                    predicted_topic, topic_confidence = predict_topic(patient_text, classifier)
-                    sentiment, sentiment_score = analyze_sentiment(patient_text)
-
-                    # Carry the safety signals accumulated DURING the session
-                    # into the report — a crisis flagged earlier must not vanish.
-                    risk_flags = st.session_state.get("session_risk_flags") or []
-                    topics = st.session_state.get("session_topics") or []
-                    notes = st.session_state.get("doctor_notes_input", "")
-                    prompt = (
-                        f"Patient Session Report:\n"
-                        f"Topic: {predicted_topic} (Confidence: {topic_confidence:.2f})\n"
-                        f"Topics observed this session: {', '.join(topics) or 'n/a'}\n"
-                        f"Overall Sentiment: {sentiment} (Score: {sentiment_score})\n"
-                        f"Risk flags raised this session: {', '.join(risk_flags) or 'none'}\n"
-                        f"Clinician notes: {notes or '(none)'}\n\n"
-                        "Provide a structured clinician-facing session summary with sections:\n"
-                        "1. **Presentation & key themes**\n"
-                        "2. **Areas of concern / risk** — explicitly address every risk flag listed above.\n"
-                        "3. **Suggested follow-up** (for the clinician to consider; not prescriptive).\n"
-                        "Use clear headings and bullet points. Do not diagnose or prescribe."
-                    )
-                    recommendations_obj = generate_advice(prompt)
-                    recommendations = (recommendations_obj if isinstance(recommendations_obj, str)
-                                       else str(recommendations_obj))
-                    st.divider()
-                    st.subheader("📝 Session report")
-                    st.markdown(f"**Predicted topic:** {predicted_topic} · **Confidence:** {topic_confidence:.2f}")
-                    st.markdown(f"**Overall sentiment:** {sentiment} ({sentiment_score})")
-                    if risk_flags:
-                        st.error("**Risk flags raised this session:** " + ", ".join(risk_flags))
-                    st.markdown(recommendations)
-                except Exception:
-                    logger.exception("Error generating report")
-                    st.error("An error occurred while generating the report. Please try again later.")
 
 
 # Main Navigation

--- a/app_chat.py
+++ b/app_chat.py
@@ -1,39 +1,61 @@
-import asyncio
+"""Streamlit entry point — the Live Session Cockpit prototype WIRED to the real backend.
+
+The pixel-perfect design (``cockpit_component/``) is mounted as a bidirectional
+Streamlit component. Typed PATIENT turns are routed to the real Python pipeline —
+deterministic crisis screen (safety.py), emotion/urgency (DistilRoBERTa),
+sentiment (RoBERTa), topic (BART zero-shot), semantic retrieval (MiniLM +
+Pinecone over the Mongo corpus), and Groq decision-support — and the chips,
+decision-support panel, RAG "why" panel, and crisis banner reflect REAL outputs.
+
+The scripted "Advance" button keeps the canned demo arc (PT-0042). Heavy ML
+imports are lazy, so the launch screen appears instantly; the first analyzed turn
+pays the model-load cost.
+
+The earlier Streamlit-native UI is preserved in ``app_live.py``.
+"""
 import hmac
-import streamlit as st
 import logging
-import uuid
-from datetime import datetime
-import ui
-from logging_config import setup_logging
-from unified_guidance import analyze_message
-from archiver import archive_conversation, archive_session
-from schemas import Conversation, Message, SessionLog
-from topic_classifier import predict_topic, load_topic_classifier
-from patient_ml import analyze_sentiment
-from llm_rag import generate_advice
-from patient_profile import (
-    get_patient_profile, create_patient_profile, update_patient_fields, get_patient_sessions,
-)
-from safety import SafetyChecker
+from pathlib import Path
+
+import streamlit as st
+import streamlit.components.v1 as components
+
 from config import settings
-from dashboard import render_dashboard
-from session_assistant import generate_session_suggestions, render_suggestions
-from patient_overview import render_patient_overview, build_patient_summary, build_history_summary
+from logging_config import setup_logging
 
-# Ensure an event loop is available
-try:
-    asyncio.get_running_loop()
-except RuntimeError:
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
-# Logging setup
 setup_logging()
 logger = logging.getLogger(__name__)
 
-# Stateless crisis screener for the guaranteed fallback.
-_safety_checker = SafetyChecker()
+st.set_page_config(
+    page_title="Live Session Assistant",
+    page_icon="🩺",
+    layout="wide",
+    initial_sidebar_state="collapsed",
+)
+
+# Full-bleed: hide Streamlit chrome and stretch the component iframe to the viewport.
+st.markdown(
+    """
+<style>
+#MainMenu, header, footer,
+[data-testid="stToolbar"], [data-testid="stDecoration"], [data-testid="stStatusWidget"] {
+    display: none !important;
+}
+[data-testid="stAppViewContainer"] { background: #eef1f6; }
+.block-container,
+[data-testid="stMainBlockContainer"],
+[data-testid="stAppViewBlockContainer"] {
+    padding: 0 !important;
+    max-width: 100% !important;
+}
+[data-testid="stVerticalBlock"] { gap: 0 !important; }
+iframe { display: block; border: none; width: 100%; height: 100vh !important; }
+[data-testid="stElementContainer"]:has(iframe),
+[data-testid="element-container"]:has(iframe) { height: 100vh !important; }
+</style>
+""",
+    unsafe_allow_html=True,
+)
 
 if not settings.app_password:
     logger.warning("APP_PASSWORD is not set — the app is running without authentication.")
@@ -45,11 +67,9 @@ def check_authentication() -> bool:
         return True
     if st.session_state.get("authenticated"):
         return True
-
     st.title("🔒 Sign in")
     password = st.text_input("Password", type="password", key="auth_password")
     if st.button("Sign in"):
-        # Constant-time comparison to avoid leaking the password via timing.
         if hmac.compare_digest(password, settings.app_password):
             st.session_state.authenticated = True
             st.rerun()
@@ -57,557 +77,124 @@ def check_authentication() -> bool:
             st.error("Incorrect password.")
     return False
 
-# Page configuration
-st.set_page_config(
-    page_title="Live Session Assistant",
-    page_icon="🩺",
-    layout="wide",
-    initial_sidebar_state="collapsed"
-)
 
-# Cockpit theme: hide default chrome, fonts, widget styling, segmented toggle.
-st.markdown(ui.css(), unsafe_allow_html=True)
-
-# Initialize session state
-if "page" not in st.session_state:
-    st.session_state.page = "landing"
-if "conversation" not in st.session_state:
-    st.session_state.conversation = []
-if "conversation_model" not in st.session_state:
-    st.session_state.conversation_model = Conversation(
-        session_id=str(uuid.uuid4()), patient_id="test_patient", messages=[]
-    )
-if "patient_profile" not in st.session_state:
-    st.session_state.patient_profile = {}
-if "session_risk_flags" not in st.session_state:
-    st.session_state.session_risk_flags = []
-if "session_topics" not in st.session_state:
-    st.session_state.session_topics = []
-if "session_suggestions" not in st.session_state:
-    st.session_state.session_suggestions = []
-
-
-def _parse_lines(text):
-    """Split a textarea value into a clean list of non-empty, stripped lines."""
-    return [line.strip() for line in (text or "").splitlines() if line.strip()]
-
-
-# Seeded demo patients so the tool can be tried without setup.
-DEMO_PERSONAS = {
-    "Alex — anxiety": {
-        "patient_id": "demo_alex",
-        "medical_history": ["generalized anxiety disorder", "chronic insomnia"],
-        "therapy_goals": ["improve sleep", "reduce daily anxiety"],
-    },
-    "Jordan — grief": {
-        "patient_id": "demo_jordan",
-        "medical_history": ["recent bereavement", "low mood"],
-        "therapy_goals": ["process grief", "re-engage with daily life"],
-    },
-    "Sam — work stress": {
-        "patient_id": "demo_sam",
-        "medical_history": ["burnout", "work-related stress"],
-        "therapy_goals": ["set boundaries", "manage workload stress"],
-    },
-}
-
-# One-click PATIENT turns that walk a distress -> crisis -> recovery arc in a demo.
-SUGGESTED_PROMPTS = [
-    {"label": "Share distress", "text": "I've been really anxious lately and I can't sleep at all"},
-    {"label": "Express a crisis", "text": "Honestly, sometimes I feel like I want to end it all"},
-    {"label": "Show improvement", "text": "Talking this through actually helps — thank you"},
-]
-
-# Session-scoped keys cleared between sessions.
-_SESSION_KEYS = (
-    "conversation", "conversation_model", "patient_profile", "session_risk_flags",
-    "session_topics", "session_suggestions", "latest_suggestions", "latest_analysis",
-    "history_summary", "doctor_notes_input", "demo_mode", "session_started", "last_report",
-)
-
-
-def _new_live_session(patient_id):
-    """Reset per-session state and start a fresh transcript for a patient."""
-    st.session_state.conversation = []
-    st.session_state.conversation_model = Conversation(
-        session_id=str(uuid.uuid4()), patient_id=patient_id, messages=[]
-    )
-    st.session_state.session_risk_flags = []
-    st.session_state.session_topics = []
-    st.session_state.session_suggestions = []
-    st.session_state.session_started = datetime.now()
-    for k in ("latest_suggestions", "latest_analysis", "history_summary",
-              "doctor_notes_input", "last_report"):
-        st.session_state.pop(k, None)
-
-
-def start_demo(persona):
-    """Begin a self-serve demo with a seeded persona (in-memory, no DB writes)."""
-    st.session_state.demo_mode = True
-    st.session_state.patient_profile = {
-        "patient_id": persona["patient_id"],
-        "medical_history": list(persona["medical_history"]),
-        "therapy_goals": list(persona["therapy_goals"]),
-    }
-    _new_live_session(persona["patient_id"])
-    st.session_state.page = "chat"
-    st.rerun()
-
-
-def reset_session():
-    """Clear the session and return to the landing page."""
-    for key in _SESSION_KEYS + ("page",):
-        st.session_state.pop(key, None)
-    st.rerun()
-
-
-def _load_history_summary():
-    try:
-        pid = st.session_state.conversation_model.patient_id
-        sid = st.session_state.conversation_model.session_id
-        sessions = [s for s in get_patient_sessions(pid) if s.get("session_id") != sid]
-        return build_history_summary(sessions)
-    except Exception:
-        logger.exception("Failed to load patient history summary")
-        return "(no prior sessions)"
-
-
-def _format_signals(analysis):
-    a = analysis or {}
-    urgency = a.get("urgency") or {}
-    sp = a.get("safety_protocol")
-    return "; ".join([
-        f"topic: {a.get('predicted_topic')} ({a.get('topic_confidence')})",
-        f"sentiment: {a.get('sentiment')} ({a.get('sentiment_score')})",
-        f"emotion: {urgency.get('label')} ({urgency.get('score')})",
-        f"crisis flag: {(sp.get('flag_type') + '/' + sp.get('action')) if sp else 'none'}",
-    ])
-
-
-def _persist_session():
-    """Archive the transcript + session log unless this is an in-memory demo.
-
-    Persistence failures are recorded in session state (not silently dropped)
-    so the clinician is warned that the turn may not have been saved — this
-    runs right before ``st.rerun()``, so a warning shown here would be lost.
-    """
-    if st.session_state.get("demo_mode"):
-        return
-    failed = False
-    try:
-        archive_conversation(st.session_state.conversation_model)
-    except Exception:
-        logger.exception("Failed to archive conversation")
-        failed = True
-    try:
-        latest = st.session_state.get("latest_analysis") or {}
-        archive_session(SessionLog(
-            session_id=st.session_state.conversation_model.session_id,
-            patient_id=st.session_state.conversation_model.patient_id,
-            detected_topics=st.session_state.session_topics,
-            risk_flags=st.session_state.session_risk_flags,
-            sentiment_score=float(latest.get("sentiment_score") or 0.0),
-            doctor_notes=st.session_state.get("doctor_notes_input", ""),
-            suggestions=st.session_state.get("session_suggestions", []),
-        ))
-    except Exception:
-        logger.exception("Failed to archive session log")
-        failed = True
-    st.session_state["persist_error"] = failed
-
-
-def _run_assistant(patient_text):
-    """Analyze a patient turn and generate decision-support for the doctor."""
-    transcript = "\n".join(
-        f"{m.get('speaker', 'patient').capitalize()}: {m['content']}"
-        for m in st.session_state.conversation
-    )
-    doctor_questions = "\n".join(
-        m["content"] for m in st.session_state.conversation if m.get("speaker") == "doctor"
-    ) or "(none yet)"
-
-    if "history_summary" not in st.session_state:
-        st.session_state.history_summary = _load_history_summary()
-
-    analysis = {"safety_protocol": _safety_checker.check_input(patient_text)}
-    suggestions = {}
-    try:
-        with st.status("Analyzing the patient turn…", expanded=True) as status:
-            analysis = analyze_message(patient_text, st.session_state.patient_profile, transcript)
-            sp = analysis.get("safety_protocol")
-            st.write(f"Safety: {sp['action'] + ' — ' + sp['flag_type'] if sp else 'no crisis indicators'}")
-            urgency = analysis.get("urgency") or {}
-            st.write(
-                f"Emotion: {urgency.get('label') or 'neutral'} · "
-                f"Topic: {analysis.get('predicted_topic') or 'n/a'} · "
-                f"Sentiment: {analysis.get('sentiment') or 'n/a'}"
-            )
-            st.write(f"Retrieved {len(analysis.get('historical_examples') or [])} similar case(s).")
-            degraded = analysis.get("errors") or []
-            if degraded:
-                st.write(f"⚠️ Degraded — unavailable: {', '.join(degraded)}")
-            status.update(label="Generating decision support…")
-            suggestions = generate_session_suggestions(
-                transcript=transcript,
-                patient_summary=build_patient_summary(st.session_state.patient_profile),
-                history_summary=st.session_state.history_summary,
-                signals=_format_signals(analysis),
-                examples=analysis.get("historical_examples"),
-                doctor_questions=doctor_questions,
-            )
-            if suggestions.get("_error"):
-                status.update(label="Decision support unavailable — model error",
-                              state="error", expanded=False)
-            elif degraded:
-                status.update(label="Decision support ready (degraded analysis)",
-                              state="complete", expanded=False)
-            else:
-                status.update(label="Decision support ready", state="complete", expanded=False)
-    except Exception:
-        logger.exception("Assistant generation error")
-        st.error("The assistant hit an unexpected error analyzing this turn. "
-                 "The deterministic safety check (shown above, if any) still applies.")
-
-    st.session_state.latest_analysis = analysis
-    st.session_state.latest_suggestions = suggestions
-
-    analytics = {
-        "topic": analysis.get("predicted_topic"),
-        "topic_confidence": analysis.get("topic_confidence"),
-        "sentiment": analysis.get("sentiment"),
-        "sentiment_score": analysis.get("sentiment_score"),
-        "safety_protocol": analysis.get("safety_protocol"),
-        "urgency": analysis.get("urgency"),
-        # Session-state only (not archived) for the "why" panel.
-        "historical_examples": analysis.get("historical_examples"),
-        "analysis_context": analysis.get("analysis_context"),
-    }
-    # Attach analytics to the patient turn (feeds the metrics dashboard).
-    if st.session_state.conversation:
-        st.session_state.conversation[-1]["analysis"] = analytics
-    lean = {k: analytics.get(k) for k in
-            ("topic", "topic_confidence", "sentiment", "sentiment_score", "safety_protocol", "urgency")}
-    if st.session_state.conversation_model.messages:
-        st.session_state.conversation_model.messages[-1].metadata = lean
-
-    # Audit trail entry.
-    st.session_state.session_suggestions.append({
-        "turn": patient_text,
-        "suggestions": {k: suggestions.get(k) for k in
-                        ("emotional_state", "next_questions", "red_flags", "missing_info", "follow_ups")},
-        "safety": analytics.get("safety_protocol"),
-    })
-
-    # Roll up distinct risk flags + topics for the session.
-    protocol = analytics.get("safety_protocol")
-    flag_type = protocol.get("flag_type") if protocol else None
-    if flag_type and flag_type not in st.session_state.session_risk_flags:
-        st.session_state.session_risk_flags.append(flag_type)
-    topic = analytics.get("topic")
-    if topic and topic not in st.session_state.session_topics:
-        st.session_state.session_topics.append(topic)
-
-
-def handle_turn(content, speaker):
-    """Append a transcript turn. Patient turns trigger the assistant; doctor
-    turns are logged as context only."""
-    is_patient = speaker == "patient"
-    st.session_state.conversation.append({
-        "speaker": speaker, "content": content,
-        "time": datetime.now().strftime("%H:%M"),
-    })
-    st.session_state.conversation_model.add_message(
-        Message(content=content, is_user=is_patient, speaker=speaker)
-    )
-    if is_patient:
-        _run_assistant(content)
-    _persist_session()
-    st.rerun()
-
-
-# --------------------------------------------------------------- cockpit glue
-def _elapsed_clock():
-    """mm:ss since the session started (updates each rerun, not live-ticking)."""
-    start = st.session_state.get("session_started")
-    if not start:
-        return "00:00"
-    secs = max(0, int((datetime.now() - start).total_seconds()))
-    return f"{secs // 60:02d}:{secs % 60:02d}"
-
-
-# Per-message transcript chips: (text, background, color).
-_AMBER = ("#fbf3e4", "#8a6a1f")
-_TOPIC = ("#eaf0fd", "#3052b8")
-
-
-def _transcript_messages():
-    """Adapt the live conversation into ui.transcript's message dicts, attaching
-    emotion/sentiment/topic chips and the crisis flag to analyzed patient turns."""
-    out = []
-    for m in st.session_state.conversation:
-        speaker = m.get("speaker") or "patient"
-        entry = {"speaker": speaker, "text": m.get("content"),
-                 "time": m.get("time", ""), "chips": [], "crisis": False}
-        a = m.get("analysis")
-        if a and speaker == "patient":
-            chips = []
-            urgency = a.get("urgency") or {}
-            if urgency.get("label"):
-                score = urgency.get("score")
-                label = str(urgency["label"]).title()
-                txt = f"{label} · {score:.0%}" if isinstance(score, (int, float)) else label
-                chips.append((txt, *_AMBER))
-            ss = a.get("sentiment_score")
-            if isinstance(ss, (int, float)):
-                bg, col = (("#fdeceb", "#b23a31") if ss < 0
-                           else ("#e8f5ef", "#2f8f6b") if ss > 0 else ("#eef1f6", "#647089"))
-                chips.append((f"{ss:+.2f}", bg, col))
-            if a.get("topic"):
-                chips.append((str(a["topic"]), *_TOPIC))
-            entry["chips"] = chips
-            entry["crisis"] = bool(a.get("safety_protocol"))
-        out.append(entry)
-    return out
-
-
-_PIPELINE_DEFS = [
-    ("Crisis screen", "regex · deterministic"),
-    ("Emotion / urgency", "DistilRoBERTa"),
-    ("Sentiment", "RoBERTa 3-class"),
-    ("Topic", "BART zero-shot"),
-    ("Semantic retrieval", "MiniLM · Pinecone"),
-    ("Generating guidance", "Groq · llama-3.3-70b"),
-]
-
-
-def _pipeline_stages():
-    """Build the analysis-pipeline panel state from the latest turn's outcome."""
-    a = st.session_state.get("latest_analysis") or {}
-    sug = st.session_state.get("latest_suggestions") or {}
-    if not a.get("analysis_context") and not a.get("safety_protocol") and not st.session_state.conversation:
-        return ([{"label": l, "sub": s, "status": "pending"} for l, s in _PIPELINE_DEFS],
-                False, "IDLE")
-    errors = a.get("errors") or []
-    sp = a.get("safety_protocol")
-    status_for = lambda key: "pending" if key in errors else "done"
-    stages = [
-        {"label": "Crisis screen", "sub": "regex · deterministic",
-         "status": "alert" if sp else "done"},
-        {"label": "Emotion / urgency", "sub": "DistilRoBERTa", "status": status_for("urgency")},
-        {"label": "Sentiment", "sub": "RoBERTa 3-class", "status": status_for("analysis")},
-        {"label": "Topic", "sub": "BART zero-shot", "status": status_for("analysis")},
-        {"label": "Semantic retrieval", "sub": "MiniLM · Pinecone", "status": status_for("retrieval")},
-        {"label": "Generating guidance", "sub": "Groq · llama-3.3-70b",
-         "status": "alert" if sug.get("_error") else "done"},
-    ]
-    degraded = bool(errors) or bool(sug.get("_error"))
-    return stages, False, ("DEGRADED" if degraded else "COMPLETE")
-
-
-def _open_session(patient_id, medical_history, therapy_goals):
-    """Load/create the patient profile and switch to the live session."""
-    try:
-        profile = get_patient_profile(patient_id)
-        if profile is None:
-            profile = create_patient_profile(
-                patient_id, medical_history=medical_history, therapy_goals=therapy_goals,
-            )
-        elif (medical_history and not profile.medical_history) or (
-            therapy_goals and not profile.therapy_goals
-        ):
-            profile = update_patient_fields(
-                patient_id,
-                medical_history=medical_history or profile.medical_history,
-                therapy_goals=therapy_goals or profile.therapy_goals,
-            )
-    except Exception:
-        logger.exception("Failed to load or create patient profile")
-        st.error("Could not load the patient profile. Please try again later.")
-        return
-
-    st.session_state.demo_mode = False
-    st.session_state.patient_profile = profile.dict()
-    _new_live_session(patient_id)
-    st.session_state.page = "chat"
-    st.rerun()
-
-
-# Landing / launch screen
-def landing_page():
-    _, mid, _ = st.columns([1, 2.2, 1])
-    with mid:
-        st.markdown(ui.launch_hero(), unsafe_allow_html=True)
-
-        patient_id = st.text_input("Patient ID", key="patient_id_input", placeholder="e.g. PT-0042")
-        with st.expander("Add clinical context (optional)"):
-            medical_history_input = st.text_area(
-                "Clinical history (one item per line)", key="medical_history_input"
-            )
-            therapy_goals_input = st.text_area(
-                "Therapy goals (one item per line)", key="therapy_goals_input"
-            )
-
-        if st.button("Open session", type="primary", use_container_width=True):
-            patient_id = (patient_id or "").strip()
-            if not patient_id:
-                st.error("Please enter a patient ID before starting.")
-            else:
-                _open_session(
-                    patient_id,
-                    _parse_lines(st.session_state.get("medical_history_input")),
-                    _parse_lines(st.session_state.get("therapy_goals_input")),
-                )
-
-        st.markdown(
-            f'<div style="display:flex;align-items:center;gap:12px;margin:18px 0 12px;">'
-            f'<span style="flex:1;height:1px;background:#dde3ee;"></span>'
-            f'<span style="font:500 10.5px/1 {ui.MONO};color:#aab2c4;letter-spacing:.04em;">'
-            f'OR START WITH A DEMO PERSONA</span>'
-            f'<span style="flex:1;height:1px;background:#dde3ee;"></span></div>',
-            unsafe_allow_html=True,
-        )
-        demo_cols = st.columns(len(DEMO_PERSONAS))
-        for i, (name, persona) in enumerate(DEMO_PERSONAS.items()):
-            if demo_cols[i].button(name, key=f"demo_persona_{i}", use_container_width=True):
-                start_demo(persona)
-
-        st.markdown(ui.launch_footer(), unsafe_allow_html=True)
-
-
-def _generate_report():
-    """Compute the end-of-session report from accumulated session signals."""
-    conv = st.session_state.conversation
-    # Classify over the patient's own turns (doctor questions skew topic/sentiment).
-    patient_text = "\n".join(m["content"] for m in conv if m.get("speaker") == "patient") \
-        or "\n".join(m["content"] for m in conv)
-    classifier = load_topic_classifier()
-    predicted_topic, topic_confidence = predict_topic(patient_text, classifier)
-    sentiment, sentiment_score = analyze_sentiment(patient_text)
-
-    risk_flags = st.session_state.get("session_risk_flags") or []
-    topics = st.session_state.get("session_topics") or []
-    notes = st.session_state.get("doctor_notes_input", "")
-    prompt = (
-        f"Patient Session Report:\n"
-        f"Topic: {predicted_topic} (Confidence: {topic_confidence:.2f})\n"
-        f"Topics observed this session: {', '.join(topics) or 'n/a'}\n"
-        f"Overall Sentiment: {sentiment} (Score: {sentiment_score})\n"
-        f"Risk flags raised this session: {', '.join(risk_flags) or 'none'}\n"
-        f"Clinician notes: {notes or '(none)'}\n\n"
-        "Provide a structured clinician-facing session summary with sections:\n"
-        "1. **Presentation & key themes**\n"
-        "2. **Areas of concern / risk** — explicitly address every risk flag listed above.\n"
-        "3. **Suggested follow-up** (for the clinician to consider; not prescriptive).\n"
-        "Use clear headings and bullet points. Do not diagnose or prescribe."
-    )
-    recommendations_obj = generate_advice(prompt)
-    recommendations = (recommendations_obj if isinstance(recommendations_obj, str)
-                       else str(recommendations_obj))
-    return {
-        "topic": predicted_topic, "topic_conf": topic_confidence,
-        "sentiment": sentiment, "score": sentiment_score,
-        "risk_flags": risk_flags, "topics": topics, "recommendations": recommendations,
-    }
-
-
-@st.dialog("End-of-session report", width="large")
-def _report_dialog():
-    pid = st.session_state.conversation_model.patient_id
-    st.caption(f"{pid} · {_elapsed_clock()} · {len(st.session_state.conversation)} turns logged")
-    if st.button("Generate / regenerate", type="primary") or "last_report" not in st.session_state:
-        with st.spinner("Generating the session report…"):
-            try:
-                st.session_state["last_report"] = _generate_report()
-            except Exception:
-                logger.exception("Error generating report")
-                st.session_state.pop("last_report", None)
-                st.error("An error occurred while generating the report. Please try again later.")
-                return
-    rep = st.session_state.get("last_report")
-    if not rep:
-        return
-    if rep["risk_flags"]:
-        st.error("**Risk flags raised this session:** " + ", ".join(rep["risk_flags"]))
-    st.markdown(f"**Predicted topic:** {rep['topic']} · **Confidence:** {rep['topic_conf']:.2f}")
-    st.markdown(f"**Overall sentiment:** {rep['sentiment']} ({rep['score']})")
-    if rep["topics"]:
-        st.caption("Topics detected: " + ", ".join(rep["topics"]))
-    st.markdown(rep["recommendations"])
-    st.caption("Decision support generated from session signals — not a diagnosis or medical "
-               "record. Review, edit, and sign before filing.")
-
-
-# Chat / cockpit page
-def chat_page():
-    # Surface a persistence failure from the previous turn (set just before the
-    # rerun that brought us here, so it could not be shown inline).
-    if st.session_state.pop("persist_error", False):
-        st.warning("⚠️ The last turn may not have been saved to the database. "
-                   "Check the patient profile exists and the database is reachable.")
-
-    pid = st.session_state.conversation_model.patient_id
-    sid = st.session_state.conversation_model.session_id
-    conv = st.session_state.conversation
-    profile = st.session_state.get("patient_profile") or {}
-    latest_analysis = st.session_state.get("latest_analysis") or {}
-    latest_suggestions = st.session_state.get("latest_suggestions") or {}
-
-    st.markdown(ui.header_bar(pid, _elapsed_clock(), len(conv)), unsafe_allow_html=True)
-
-    c_info, c_report, c_new = st.columns([6, 1.6, 1.2])
-    if st.session_state.get("demo_mode"):
-        c_info.caption("Demo mode — sample patient, nothing is saved.")
-    if c_report.button("End session & report", type="primary", use_container_width=True):
-        _report_dialog()
-    if c_new.button("New session", use_container_width=True):
-        reset_session()
-
-    left, center, right = st.columns([316, 480, 404], gap="medium")
-
-    # LEFT — patient context + clinician notes
-    with left:
-        render_patient_overview(pid, profile, exclude_session_id=sid)
-        st.markdown('<div class="lsa-h" style="margin-top:4px;"><span class="bar"></span>'
-                    '<span class="t">CLINICIAN NOTES</span></div>', unsafe_allow_html=True)
-        st.text_area("Clinician notes", key="doctor_notes_input", height=110,
-                     label_visibility="collapsed",
-                     placeholder="Private notes for this session — saved with the session…")
-
-    # CENTER — crisis banner + transcript + composer
-    with center:
-        sp = latest_analysis.get("safety_protocol")
-        if sp:
-            st.markdown(ui.crisis_banner(sp.get("action"), sp.get("flag_type"), sp.get("response")),
-                        unsafe_allow_html=True)
-        st.markdown(ui.transcript(_transcript_messages(), len(conv)), unsafe_allow_html=True)
-
-        speaker_label = st.radio("Log turn as", ["Patient", "Doctor"], horizontal=True,
-                                 key="speaker_select", label_visibility="collapsed")
-        if st.session_state.get("demo_mode"):
-            st.caption("Quick demo patient turns")
-            prompt_cols = st.columns(len(SUGGESTED_PROMPTS))
-            for i, p in enumerate(SUGGESTED_PROMPTS):
-                if prompt_cols[i].button(p["label"], key=f"suggested_{i}", use_container_width=True):
-                    handle_turn(p["text"], "patient")
-
-    # RIGHT — analysis pipeline + decision support + session metrics
-    with right:
-        stages, running, status_label = _pipeline_stages()
-        st.markdown(ui.pipeline_panel(stages, running, status_label), unsafe_allow_html=True)
-        render_suggestions(latest_suggestions, latest_analysis)
-        render_dashboard(conv, profile)
-
-    # Pinned two-channel input.
-    turn = st.chat_input(f"Log what the {speaker_label.lower()} said…")
-    if turn:
-        handle_turn(turn, "patient" if speaker_label == "Patient" else "doctor")
-
-
-# Main Navigation
 if not check_authentication():
     st.stop()
 
-if st.session_state.page == "landing":
-    landing_page()
-elif st.session_state.page == "chat":
-    chat_page()
+# Bidirectional component wrapping the prototype.
+_COMPONENT_DIR = Path(__file__).parent / "cockpit_component"
+_lsa_cockpit = components.declare_component("lsa_cockpit", path=str(_COMPONENT_DIR))
+
+# Demo patient profile — matches the cockpit's PT-0042 overview card so the real
+# pipeline's grounding is consistent with what the clinician sees.
+_DEMO_PROFILE = {
+    "patient_id": "PT-0042",
+    "medical_history": ["generalized anxiety disorder", "panic attacks"],
+    "therapy_goals": ["reduce daily anxiety", "manage panic episodes"],
+}
+
+
+def _fmt_score(n) -> str:
+    try:
+        n = float(n)
+    except (TypeError, ValueError):
+        return "0.00"
+    return ("+%.2f" % n) if n >= 0 else ("%.2f" % n)
+
+
+def _run_real_turn(text: str, transcript: str) -> dict:
+    """Run the real analysis + decision-support pipeline for one patient turn and
+    shape it into the payload the prototype's React component expects."""
+    from unified_guidance import analyze_message
+    from session_assistant import generate_session_suggestions
+    from patient_overview import build_patient_summary
+
+    analysis = analyze_message(text, _DEMO_PROFILE, transcript)
+    urgency = analysis.get("urgency") or {}
+    sp = analysis.get("safety_protocol")
+
+    emotion = urgency.get("label") or "neutral"
+    e_score = urgency.get("score") or 0.0
+    sentiment = (analysis.get("sentiment") or "neutral").lower()
+    s_score = analysis.get("sentiment_score") or 0.0
+    topic = analysis.get("predicted_topic") or "general"
+    t_conf = analysis.get("topic_confidence") or 0.0
+
+    signals = (
+        f"topic: {topic} ({t_conf}); sentiment: {sentiment} ({s_score}); "
+        f"emotion: {emotion} ({e_score}); "
+        f"crisis flag: {(sp.get('flag_type') + '/' + sp.get('action')) if sp else 'none'}"
+    )
+    suggestions = generate_session_suggestions(
+        transcript=transcript,
+        patient_summary=build_patient_summary(_DEMO_PROFILE),
+        history_summary="(no prior sessions in this demo)",
+        signals=signals,
+        examples=analysis.get("historical_examples"),
+        doctor_questions="(see transcript)",
+    )
+
+    why_signals = [
+        {"k": "Emotion (DistilRoBERTa)", "v": f"{emotion} · {round(float(e_score) * 100)}%"},
+        {"k": "Sentiment (RoBERTa)", "v": f"{sentiment} · {_fmt_score(s_score)}"},
+        {"k": "Topic (BART zero-shot)", "v": f"{topic} · {round(float(t_conf) * 100)}%"},
+        {"k": "Crisis screen", "v": (f"{sp['flag_type']} · {sp['action']}") if sp else "clear"},
+    ]
+    cases = [
+        {
+            "id": str(ex.get("questionID") or ex.get("id") or "—"),
+            "sim": "",
+            "q": (ex.get("questionText") or "")[:200],
+            "a": (ex.get("answerText") or "")[:200],
+        }
+        for ex in (analysis.get("historical_examples") or [])[:3]
+    ]
+
+    return {
+        "analysis": {
+            "emotion": emotion,
+            "emotionScore": float(e_score),
+            "sentiment": sentiment,
+            "sentimentScore": float(s_score),
+            "topic": topic,
+            "topicConf": float(t_conf),
+        },
+        "suggestions": {
+            k: suggestions.get(k)
+            for k in ("emotional_state", "state_confidence", "red_flags",
+                      "missing_info", "next_questions", "follow_ups", "caveat")
+        },
+        "why": {"signals": why_signals, "cases": cases,
+                "context": analysis.get("analysis_context") or ""},
+        "crisis": ({"flag_type": sp["flag_type"], "action": sp["action"], "response": sp["response"]}
+                   if sp else None),
+        "errors": analysis.get("errors") or [],
+    }
+
+
+_ERROR_RESULT = {
+    "analysis": {"emotion": "neutral", "emotionScore": 0.0, "sentiment": "neutral",
+                 "sentimentScore": 0.0, "topic": "general", "topicConf": 0.0},
+    "suggestions": {"emotional_state": "", "state_confidence": "low", "red_flags": [],
+                    "missing_info": [], "next_questions": [], "follow_ups": [],
+                    "caveat": "The analysis pipeline errored for this turn."},
+    "why": {"signals": [], "cases": [], "context": ""},
+    "crisis": None,
+}
+
+# Render the component, passing the most recent result back to the iframe.
+payload = _lsa_cockpit(result=st.session_state.get("lsa_result"), key="lsa_cockpit", default=None)
+
+# A new patient turn arrived from the iframe — run the real pipeline and push it back.
+if isinstance(payload, dict) and payload.get("kind") == "patient_turn":
+    nonce = payload.get("nonce")
+    if nonce is not None and nonce != st.session_state.get("lsa_handled_nonce"):
+        st.session_state["lsa_handled_nonce"] = nonce
+        try:
+            result = _run_real_turn(payload.get("text", ""), payload.get("transcript", ""))
+        except Exception:
+            logger.exception("Real pipeline failed for a patient turn")
+            result = dict(_ERROR_RESULT)
+        result["nonce"] = nonce
+        st.session_state["lsa_result"] = result
+        st.rerun()

--- a/app_live.py
+++ b/app_live.py
@@ -1,0 +1,613 @@
+import asyncio
+import hmac
+import streamlit as st
+import logging
+import uuid
+from datetime import datetime
+import ui
+from logging_config import setup_logging
+from unified_guidance import analyze_message
+from archiver import archive_conversation, archive_session
+from schemas import Conversation, Message, SessionLog
+from topic_classifier import predict_topic, load_topic_classifier
+from patient_ml import analyze_sentiment
+from llm_rag import generate_advice
+from patient_profile import (
+    get_patient_profile, create_patient_profile, update_patient_fields, get_patient_sessions,
+)
+from safety import SafetyChecker
+from config import settings
+from dashboard import render_dashboard
+from session_assistant import generate_session_suggestions, render_suggestions
+from patient_overview import render_patient_overview, build_patient_summary, build_history_summary
+
+# Ensure an event loop is available
+try:
+    asyncio.get_running_loop()
+except RuntimeError:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+# Logging setup
+setup_logging()
+logger = logging.getLogger(__name__)
+
+# Stateless crisis screener for the guaranteed fallback.
+_safety_checker = SafetyChecker()
+
+if not settings.app_password:
+    logger.warning("APP_PASSWORD is not set — the app is running without authentication.")
+
+
+def check_authentication() -> bool:
+    """Gate the app behind a shared password when settings.app_password is set."""
+    if not settings.app_password:
+        return True
+    if st.session_state.get("authenticated"):
+        return True
+
+    st.title("🔒 Sign in")
+    password = st.text_input("Password", type="password", key="auth_password")
+    if st.button("Sign in"):
+        # Constant-time comparison to avoid leaking the password via timing.
+        if hmac.compare_digest(password, settings.app_password):
+            st.session_state.authenticated = True
+            st.rerun()
+        else:
+            st.error("Incorrect password.")
+    return False
+
+# Page configuration
+st.set_page_config(
+    page_title="Live Session Assistant",
+    page_icon="🩺",
+    layout="wide",
+    initial_sidebar_state="collapsed"
+)
+
+# Cockpit theme: hide default chrome, fonts, widget styling, segmented toggle.
+st.markdown(ui.css(), unsafe_allow_html=True)
+
+# Initialize session state
+if "page" not in st.session_state:
+    st.session_state.page = "landing"
+if "conversation" not in st.session_state:
+    st.session_state.conversation = []
+if "conversation_model" not in st.session_state:
+    st.session_state.conversation_model = Conversation(
+        session_id=str(uuid.uuid4()), patient_id="test_patient", messages=[]
+    )
+if "patient_profile" not in st.session_state:
+    st.session_state.patient_profile = {}
+if "session_risk_flags" not in st.session_state:
+    st.session_state.session_risk_flags = []
+if "session_topics" not in st.session_state:
+    st.session_state.session_topics = []
+if "session_suggestions" not in st.session_state:
+    st.session_state.session_suggestions = []
+
+
+def _parse_lines(text):
+    """Split a textarea value into a clean list of non-empty, stripped lines."""
+    return [line.strip() for line in (text or "").splitlines() if line.strip()]
+
+
+# Seeded demo patients so the tool can be tried without setup.
+DEMO_PERSONAS = {
+    "Alex — anxiety": {
+        "patient_id": "demo_alex",
+        "medical_history": ["generalized anxiety disorder", "chronic insomnia"],
+        "therapy_goals": ["improve sleep", "reduce daily anxiety"],
+    },
+    "Jordan — grief": {
+        "patient_id": "demo_jordan",
+        "medical_history": ["recent bereavement", "low mood"],
+        "therapy_goals": ["process grief", "re-engage with daily life"],
+    },
+    "Sam — work stress": {
+        "patient_id": "demo_sam",
+        "medical_history": ["burnout", "work-related stress"],
+        "therapy_goals": ["set boundaries", "manage workload stress"],
+    },
+}
+
+# One-click PATIENT turns that walk a distress -> crisis -> recovery arc in a demo.
+SUGGESTED_PROMPTS = [
+    {"label": "Share distress", "text": "I've been really anxious lately and I can't sleep at all"},
+    {"label": "Express a crisis", "text": "Honestly, sometimes I feel like I want to end it all"},
+    {"label": "Show improvement", "text": "Talking this through actually helps — thank you"},
+]
+
+# Session-scoped keys cleared between sessions.
+_SESSION_KEYS = (
+    "conversation", "conversation_model", "patient_profile", "session_risk_flags",
+    "session_topics", "session_suggestions", "latest_suggestions", "latest_analysis",
+    "history_summary", "doctor_notes_input", "demo_mode", "session_started", "last_report",
+)
+
+
+def _new_live_session(patient_id):
+    """Reset per-session state and start a fresh transcript for a patient."""
+    st.session_state.conversation = []
+    st.session_state.conversation_model = Conversation(
+        session_id=str(uuid.uuid4()), patient_id=patient_id, messages=[]
+    )
+    st.session_state.session_risk_flags = []
+    st.session_state.session_topics = []
+    st.session_state.session_suggestions = []
+    st.session_state.session_started = datetime.now()
+    for k in ("latest_suggestions", "latest_analysis", "history_summary",
+              "doctor_notes_input", "last_report"):
+        st.session_state.pop(k, None)
+
+
+def start_demo(persona):
+    """Begin a self-serve demo with a seeded persona (in-memory, no DB writes)."""
+    st.session_state.demo_mode = True
+    st.session_state.patient_profile = {
+        "patient_id": persona["patient_id"],
+        "medical_history": list(persona["medical_history"]),
+        "therapy_goals": list(persona["therapy_goals"]),
+    }
+    _new_live_session(persona["patient_id"])
+    st.session_state.page = "chat"
+    st.rerun()
+
+
+def reset_session():
+    """Clear the session and return to the landing page."""
+    for key in _SESSION_KEYS + ("page",):
+        st.session_state.pop(key, None)
+    st.rerun()
+
+
+def _load_history_summary():
+    try:
+        pid = st.session_state.conversation_model.patient_id
+        sid = st.session_state.conversation_model.session_id
+        sessions = [s for s in get_patient_sessions(pid) if s.get("session_id") != sid]
+        return build_history_summary(sessions)
+    except Exception:
+        logger.exception("Failed to load patient history summary")
+        return "(no prior sessions)"
+
+
+def _format_signals(analysis):
+    a = analysis or {}
+    urgency = a.get("urgency") or {}
+    sp = a.get("safety_protocol")
+    return "; ".join([
+        f"topic: {a.get('predicted_topic')} ({a.get('topic_confidence')})",
+        f"sentiment: {a.get('sentiment')} ({a.get('sentiment_score')})",
+        f"emotion: {urgency.get('label')} ({urgency.get('score')})",
+        f"crisis flag: {(sp.get('flag_type') + '/' + sp.get('action')) if sp else 'none'}",
+    ])
+
+
+def _persist_session():
+    """Archive the transcript + session log unless this is an in-memory demo.
+
+    Persistence failures are recorded in session state (not silently dropped)
+    so the clinician is warned that the turn may not have been saved — this
+    runs right before ``st.rerun()``, so a warning shown here would be lost.
+    """
+    if st.session_state.get("demo_mode"):
+        return
+    failed = False
+    try:
+        archive_conversation(st.session_state.conversation_model)
+    except Exception:
+        logger.exception("Failed to archive conversation")
+        failed = True
+    try:
+        latest = st.session_state.get("latest_analysis") or {}
+        archive_session(SessionLog(
+            session_id=st.session_state.conversation_model.session_id,
+            patient_id=st.session_state.conversation_model.patient_id,
+            detected_topics=st.session_state.session_topics,
+            risk_flags=st.session_state.session_risk_flags,
+            sentiment_score=float(latest.get("sentiment_score") or 0.0),
+            doctor_notes=st.session_state.get("doctor_notes_input", ""),
+            suggestions=st.session_state.get("session_suggestions", []),
+        ))
+    except Exception:
+        logger.exception("Failed to archive session log")
+        failed = True
+    st.session_state["persist_error"] = failed
+
+
+def _run_assistant(patient_text):
+    """Analyze a patient turn and generate decision-support for the doctor."""
+    transcript = "\n".join(
+        f"{m.get('speaker', 'patient').capitalize()}: {m['content']}"
+        for m in st.session_state.conversation
+    )
+    doctor_questions = "\n".join(
+        m["content"] for m in st.session_state.conversation if m.get("speaker") == "doctor"
+    ) or "(none yet)"
+
+    if "history_summary" not in st.session_state:
+        st.session_state.history_summary = _load_history_summary()
+
+    analysis = {"safety_protocol": _safety_checker.check_input(patient_text)}
+    suggestions = {}
+    try:
+        with st.status("Analyzing the patient turn…", expanded=True) as status:
+            analysis = analyze_message(patient_text, st.session_state.patient_profile, transcript)
+            sp = analysis.get("safety_protocol")
+            st.write(f"Safety: {sp['action'] + ' — ' + sp['flag_type'] if sp else 'no crisis indicators'}")
+            urgency = analysis.get("urgency") or {}
+            st.write(
+                f"Emotion: {urgency.get('label') or 'neutral'} · "
+                f"Topic: {analysis.get('predicted_topic') or 'n/a'} · "
+                f"Sentiment: {analysis.get('sentiment') or 'n/a'}"
+            )
+            st.write(f"Retrieved {len(analysis.get('historical_examples') or [])} similar case(s).")
+            degraded = analysis.get("errors") or []
+            if degraded:
+                st.write(f"⚠️ Degraded — unavailable: {', '.join(degraded)}")
+            status.update(label="Generating decision support…")
+            suggestions = generate_session_suggestions(
+                transcript=transcript,
+                patient_summary=build_patient_summary(st.session_state.patient_profile),
+                history_summary=st.session_state.history_summary,
+                signals=_format_signals(analysis),
+                examples=analysis.get("historical_examples"),
+                doctor_questions=doctor_questions,
+            )
+            if suggestions.get("_error"):
+                status.update(label="Decision support unavailable — model error",
+                              state="error", expanded=False)
+            elif degraded:
+                status.update(label="Decision support ready (degraded analysis)",
+                              state="complete", expanded=False)
+            else:
+                status.update(label="Decision support ready", state="complete", expanded=False)
+    except Exception:
+        logger.exception("Assistant generation error")
+        st.error("The assistant hit an unexpected error analyzing this turn. "
+                 "The deterministic safety check (shown above, if any) still applies.")
+
+    st.session_state.latest_analysis = analysis
+    st.session_state.latest_suggestions = suggestions
+
+    analytics = {
+        "topic": analysis.get("predicted_topic"),
+        "topic_confidence": analysis.get("topic_confidence"),
+        "sentiment": analysis.get("sentiment"),
+        "sentiment_score": analysis.get("sentiment_score"),
+        "safety_protocol": analysis.get("safety_protocol"),
+        "urgency": analysis.get("urgency"),
+        # Session-state only (not archived) for the "why" panel.
+        "historical_examples": analysis.get("historical_examples"),
+        "analysis_context": analysis.get("analysis_context"),
+    }
+    # Attach analytics to the patient turn (feeds the metrics dashboard).
+    if st.session_state.conversation:
+        st.session_state.conversation[-1]["analysis"] = analytics
+    lean = {k: analytics.get(k) for k in
+            ("topic", "topic_confidence", "sentiment", "sentiment_score", "safety_protocol", "urgency")}
+    if st.session_state.conversation_model.messages:
+        st.session_state.conversation_model.messages[-1].metadata = lean
+
+    # Audit trail entry.
+    st.session_state.session_suggestions.append({
+        "turn": patient_text,
+        "suggestions": {k: suggestions.get(k) for k in
+                        ("emotional_state", "next_questions", "red_flags", "missing_info", "follow_ups")},
+        "safety": analytics.get("safety_protocol"),
+    })
+
+    # Roll up distinct risk flags + topics for the session.
+    protocol = analytics.get("safety_protocol")
+    flag_type = protocol.get("flag_type") if protocol else None
+    if flag_type and flag_type not in st.session_state.session_risk_flags:
+        st.session_state.session_risk_flags.append(flag_type)
+    topic = analytics.get("topic")
+    if topic and topic not in st.session_state.session_topics:
+        st.session_state.session_topics.append(topic)
+
+
+def handle_turn(content, speaker):
+    """Append a transcript turn. Patient turns trigger the assistant; doctor
+    turns are logged as context only."""
+    is_patient = speaker == "patient"
+    st.session_state.conversation.append({
+        "speaker": speaker, "content": content,
+        "time": datetime.now().strftime("%H:%M"),
+    })
+    st.session_state.conversation_model.add_message(
+        Message(content=content, is_user=is_patient, speaker=speaker)
+    )
+    if is_patient:
+        _run_assistant(content)
+    _persist_session()
+    st.rerun()
+
+
+# --------------------------------------------------------------- cockpit glue
+def _elapsed_clock():
+    """mm:ss since the session started (updates each rerun, not live-ticking)."""
+    start = st.session_state.get("session_started")
+    if not start:
+        return "00:00"
+    secs = max(0, int((datetime.now() - start).total_seconds()))
+    return f"{secs // 60:02d}:{secs % 60:02d}"
+
+
+# Per-message transcript chips: (text, background, color).
+_AMBER = ("#fbf3e4", "#8a6a1f")
+_TOPIC = ("#eaf0fd", "#3052b8")
+
+
+def _transcript_messages():
+    """Adapt the live conversation into ui.transcript's message dicts, attaching
+    emotion/sentiment/topic chips and the crisis flag to analyzed patient turns."""
+    out = []
+    for m in st.session_state.conversation:
+        speaker = m.get("speaker") or "patient"
+        entry = {"speaker": speaker, "text": m.get("content"),
+                 "time": m.get("time", ""), "chips": [], "crisis": False}
+        a = m.get("analysis")
+        if a and speaker == "patient":
+            chips = []
+            urgency = a.get("urgency") or {}
+            if urgency.get("label"):
+                score = urgency.get("score")
+                label = str(urgency["label"]).title()
+                txt = f"{label} · {score:.0%}" if isinstance(score, (int, float)) else label
+                chips.append((txt, *_AMBER))
+            ss = a.get("sentiment_score")
+            if isinstance(ss, (int, float)):
+                bg, col = (("#fdeceb", "#b23a31") if ss < 0
+                           else ("#e8f5ef", "#2f8f6b") if ss > 0 else ("#eef1f6", "#647089"))
+                chips.append((f"{ss:+.2f}", bg, col))
+            if a.get("topic"):
+                chips.append((str(a["topic"]), *_TOPIC))
+            entry["chips"] = chips
+            entry["crisis"] = bool(a.get("safety_protocol"))
+        out.append(entry)
+    return out
+
+
+_PIPELINE_DEFS = [
+    ("Crisis screen", "regex · deterministic"),
+    ("Emotion / urgency", "DistilRoBERTa"),
+    ("Sentiment", "RoBERTa 3-class"),
+    ("Topic", "BART zero-shot"),
+    ("Semantic retrieval", "MiniLM · Pinecone"),
+    ("Generating guidance", "Groq · llama-3.3-70b"),
+]
+
+
+def _pipeline_stages():
+    """Build the analysis-pipeline panel state from the latest turn's outcome."""
+    a = st.session_state.get("latest_analysis") or {}
+    sug = st.session_state.get("latest_suggestions") or {}
+    if not a.get("analysis_context") and not a.get("safety_protocol") and not st.session_state.conversation:
+        return ([{"label": l, "sub": s, "status": "pending"} for l, s in _PIPELINE_DEFS],
+                False, "IDLE")
+    errors = a.get("errors") or []
+    sp = a.get("safety_protocol")
+    status_for = lambda key: "pending" if key in errors else "done"
+    stages = [
+        {"label": "Crisis screen", "sub": "regex · deterministic",
+         "status": "alert" if sp else "done"},
+        {"label": "Emotion / urgency", "sub": "DistilRoBERTa", "status": status_for("urgency")},
+        {"label": "Sentiment", "sub": "RoBERTa 3-class", "status": status_for("analysis")},
+        {"label": "Topic", "sub": "BART zero-shot", "status": status_for("analysis")},
+        {"label": "Semantic retrieval", "sub": "MiniLM · Pinecone", "status": status_for("retrieval")},
+        {"label": "Generating guidance", "sub": "Groq · llama-3.3-70b",
+         "status": "alert" if sug.get("_error") else "done"},
+    ]
+    degraded = bool(errors) or bool(sug.get("_error"))
+    return stages, False, ("DEGRADED" if degraded else "COMPLETE")
+
+
+def _open_session(patient_id, medical_history, therapy_goals):
+    """Load/create the patient profile and switch to the live session."""
+    try:
+        profile = get_patient_profile(patient_id)
+        if profile is None:
+            profile = create_patient_profile(
+                patient_id, medical_history=medical_history, therapy_goals=therapy_goals,
+            )
+        elif (medical_history and not profile.medical_history) or (
+            therapy_goals and not profile.therapy_goals
+        ):
+            profile = update_patient_fields(
+                patient_id,
+                medical_history=medical_history or profile.medical_history,
+                therapy_goals=therapy_goals or profile.therapy_goals,
+            )
+    except Exception:
+        logger.exception("Failed to load or create patient profile")
+        st.error("Could not load the patient profile. Please try again later.")
+        return
+
+    st.session_state.demo_mode = False
+    st.session_state.patient_profile = profile.dict()
+    _new_live_session(patient_id)
+    st.session_state.page = "chat"
+    st.rerun()
+
+
+# Landing / launch screen
+def landing_page():
+    _, mid, _ = st.columns([1, 2.2, 1])
+    with mid:
+        st.markdown(ui.launch_hero(), unsafe_allow_html=True)
+
+        patient_id = st.text_input("Patient ID", key="patient_id_input", placeholder="e.g. PT-0042")
+        with st.expander("Add clinical context (optional)"):
+            medical_history_input = st.text_area(
+                "Clinical history (one item per line)", key="medical_history_input"
+            )
+            therapy_goals_input = st.text_area(
+                "Therapy goals (one item per line)", key="therapy_goals_input"
+            )
+
+        if st.button("Open session", type="primary", use_container_width=True):
+            patient_id = (patient_id or "").strip()
+            if not patient_id:
+                st.error("Please enter a patient ID before starting.")
+            else:
+                _open_session(
+                    patient_id,
+                    _parse_lines(st.session_state.get("medical_history_input")),
+                    _parse_lines(st.session_state.get("therapy_goals_input")),
+                )
+
+        st.markdown(
+            f'<div style="display:flex;align-items:center;gap:12px;margin:18px 0 12px;">'
+            f'<span style="flex:1;height:1px;background:#dde3ee;"></span>'
+            f'<span style="font:500 10.5px/1 {ui.MONO};color:#aab2c4;letter-spacing:.04em;">'
+            f'OR START WITH A DEMO PERSONA</span>'
+            f'<span style="flex:1;height:1px;background:#dde3ee;"></span></div>',
+            unsafe_allow_html=True,
+        )
+        demo_cols = st.columns(len(DEMO_PERSONAS))
+        for i, (name, persona) in enumerate(DEMO_PERSONAS.items()):
+            if demo_cols[i].button(name, key=f"demo_persona_{i}", use_container_width=True):
+                start_demo(persona)
+
+        st.markdown(ui.launch_footer(), unsafe_allow_html=True)
+
+
+def _generate_report():
+    """Compute the end-of-session report from accumulated session signals."""
+    conv = st.session_state.conversation
+    # Classify over the patient's own turns (doctor questions skew topic/sentiment).
+    patient_text = "\n".join(m["content"] for m in conv if m.get("speaker") == "patient") \
+        or "\n".join(m["content"] for m in conv)
+    classifier = load_topic_classifier()
+    predicted_topic, topic_confidence = predict_topic(patient_text, classifier)
+    sentiment, sentiment_score = analyze_sentiment(patient_text)
+
+    risk_flags = st.session_state.get("session_risk_flags") or []
+    topics = st.session_state.get("session_topics") or []
+    notes = st.session_state.get("doctor_notes_input", "")
+    prompt = (
+        f"Patient Session Report:\n"
+        f"Topic: {predicted_topic} (Confidence: {topic_confidence:.2f})\n"
+        f"Topics observed this session: {', '.join(topics) or 'n/a'}\n"
+        f"Overall Sentiment: {sentiment} (Score: {sentiment_score})\n"
+        f"Risk flags raised this session: {', '.join(risk_flags) or 'none'}\n"
+        f"Clinician notes: {notes or '(none)'}\n\n"
+        "Provide a structured clinician-facing session summary with sections:\n"
+        "1. **Presentation & key themes**\n"
+        "2. **Areas of concern / risk** — explicitly address every risk flag listed above.\n"
+        "3. **Suggested follow-up** (for the clinician to consider; not prescriptive).\n"
+        "Use clear headings and bullet points. Do not diagnose or prescribe."
+    )
+    recommendations_obj = generate_advice(prompt)
+    recommendations = (recommendations_obj if isinstance(recommendations_obj, str)
+                       else str(recommendations_obj))
+    return {
+        "topic": predicted_topic, "topic_conf": topic_confidence,
+        "sentiment": sentiment, "score": sentiment_score,
+        "risk_flags": risk_flags, "topics": topics, "recommendations": recommendations,
+    }
+
+
+@st.dialog("End-of-session report", width="large")
+def _report_dialog():
+    pid = st.session_state.conversation_model.patient_id
+    st.caption(f"{pid} · {_elapsed_clock()} · {len(st.session_state.conversation)} turns logged")
+    if st.button("Generate / regenerate", type="primary") or "last_report" not in st.session_state:
+        with st.spinner("Generating the session report…"):
+            try:
+                st.session_state["last_report"] = _generate_report()
+            except Exception:
+                logger.exception("Error generating report")
+                st.session_state.pop("last_report", None)
+                st.error("An error occurred while generating the report. Please try again later.")
+                return
+    rep = st.session_state.get("last_report")
+    if not rep:
+        return
+    if rep["risk_flags"]:
+        st.error("**Risk flags raised this session:** " + ", ".join(rep["risk_flags"]))
+    st.markdown(f"**Predicted topic:** {rep['topic']} · **Confidence:** {rep['topic_conf']:.2f}")
+    st.markdown(f"**Overall sentiment:** {rep['sentiment']} ({rep['score']})")
+    if rep["topics"]:
+        st.caption("Topics detected: " + ", ".join(rep["topics"]))
+    st.markdown(rep["recommendations"])
+    st.caption("Decision support generated from session signals — not a diagnosis or medical "
+               "record. Review, edit, and sign before filing.")
+
+
+# Chat / cockpit page
+def chat_page():
+    # Surface a persistence failure from the previous turn (set just before the
+    # rerun that brought us here, so it could not be shown inline).
+    if st.session_state.pop("persist_error", False):
+        st.warning("⚠️ The last turn may not have been saved to the database. "
+                   "Check the patient profile exists and the database is reachable.")
+
+    pid = st.session_state.conversation_model.patient_id
+    sid = st.session_state.conversation_model.session_id
+    conv = st.session_state.conversation
+    profile = st.session_state.get("patient_profile") or {}
+    latest_analysis = st.session_state.get("latest_analysis") or {}
+    latest_suggestions = st.session_state.get("latest_suggestions") or {}
+
+    st.markdown(ui.header_bar(pid, _elapsed_clock(), len(conv)), unsafe_allow_html=True)
+
+    c_info, c_report, c_new = st.columns([6, 1.6, 1.2])
+    if st.session_state.get("demo_mode"):
+        c_info.caption("Demo mode — sample patient, nothing is saved.")
+    if c_report.button("End session & report", type="primary", use_container_width=True):
+        _report_dialog()
+    if c_new.button("New session", use_container_width=True):
+        reset_session()
+
+    left, center, right = st.columns([316, 480, 404], gap="medium")
+
+    # LEFT — patient context + clinician notes
+    with left:
+        render_patient_overview(pid, profile, exclude_session_id=sid)
+        st.markdown('<div class="lsa-h" style="margin-top:4px;"><span class="bar"></span>'
+                    '<span class="t">CLINICIAN NOTES</span></div>', unsafe_allow_html=True)
+        st.text_area("Clinician notes", key="doctor_notes_input", height=110,
+                     label_visibility="collapsed",
+                     placeholder="Private notes for this session — saved with the session…")
+
+    # CENTER — crisis banner + transcript + composer
+    with center:
+        sp = latest_analysis.get("safety_protocol")
+        if sp:
+            st.markdown(ui.crisis_banner(sp.get("action"), sp.get("flag_type"), sp.get("response")),
+                        unsafe_allow_html=True)
+        st.markdown(ui.transcript(_transcript_messages(), len(conv)), unsafe_allow_html=True)
+
+        speaker_label = st.radio("Log turn as", ["Patient", "Doctor"], horizontal=True,
+                                 key="speaker_select", label_visibility="collapsed")
+        if st.session_state.get("demo_mode"):
+            st.caption("Quick demo patient turns")
+            prompt_cols = st.columns(len(SUGGESTED_PROMPTS))
+            for i, p in enumerate(SUGGESTED_PROMPTS):
+                if prompt_cols[i].button(p["label"], key=f"suggested_{i}", use_container_width=True):
+                    handle_turn(p["text"], "patient")
+
+    # RIGHT — analysis pipeline + decision support + session metrics
+    with right:
+        stages, running, status_label = _pipeline_stages()
+        st.markdown(ui.pipeline_panel(stages, running, status_label), unsafe_allow_html=True)
+        render_suggestions(latest_suggestions, latest_analysis)
+        render_dashboard(conv, profile)
+
+    # Pinned two-channel input.
+    turn = st.chat_input(f"Log what the {speaker_label.lower()} said…")
+    if turn:
+        handle_turn(turn, "patient" if speaker_label == "Patient" else "doctor")
+
+
+# Main Navigation
+if not check_authentication():
+    st.stop()
+
+if st.session_state.page == "landing":
+    landing_page()
+elif st.session_state.page == "chat":
+    chat_page()

--- a/cockpit_component/index.html
+++ b/cockpit_component/index.html
@@ -1,0 +1,1134 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+<script>
+/* Streamlit bidirectional-component bridge (postMessage protocol, no build step). */
+(function () {
+  function post(type, data) {
+    try { window.parent.postMessage(Object.assign({ isStreamlitMessage: true, type: type }, data), "*"); } catch (e) {}
+  }
+  window.Streamlit = {
+    setComponentReady: function () { post("streamlit:componentReady", { apiVersion: 1 }); },
+    setFrameHeight: function (h) { post("streamlit:setFrameHeight", { height: h }); },
+    setComponentValue: function (v) { post("streamlit:setComponentValue", { value: v, dataType: "json" }); }
+  };
+  window.addEventListener("message", function (e) {
+    if (e.data && e.data.type === "streamlit:render") {
+      window.__lsaPendingArgs = (e.data.args || null);
+      if (window.__lsaApply) window.__lsaApply(window.__lsaPendingArgs);
+    }
+  });
+})();
+</script>
+<script src="./support.js"></script>
+<template id="__bundler_thumbnail" data-bg-color="#eef1f6">
+<svg viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="800" fill="#eef1f6"/>
+  <circle cx="600" cy="330" r="120" fill="none" stroke="#3563d4" stroke-width="34" stroke-linecap="round" stroke-dasharray="540 200" transform="rotate(-90 600 330)"/>
+  <rect x="430" y="500" width="340" height="26" rx="13" fill="#28304a"/>
+  <rect x="480" y="552" width="240" height="18" rx="9" fill="#aab2c4"/>
+  <rect x="520" y="600" width="160" height="40" rx="20" fill="#fdf4f3" stroke="#f0d9d6" stroke-width="2"/>
+  <circle cx="556" cy="620" r="6" fill="#c2362f"/>
+</svg>
+</template>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body { background: #eef1f6; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  @keyframes softpulse { 0%,100% { opacity: 1; } 50% { opacity: .45; } }
+  @keyframes crisisPulse { 0%,100% { box-shadow: 0 0 0 0 rgba(194,54,47,.28); } 50% { box-shadow: 0 0 0 5px rgba(194,54,47,0); } }
+  .lsa-scroll::-webkit-scrollbar { width: 9px; }
+  .lsa-scroll::-webkit-scrollbar-thumb { background: #d3dae8; border-radius: 6px; border: 2px solid #fff; }
+  .lsa-scroll::-webkit-scrollbar-track { background: transparent; }
+</style>
+</helmet>
+
+<div style="height:100vh;overflow:hidden;font-family:'Public Sans',system-ui,sans-serif;color:#1a2235;background:#eef1f6;">
+
+  <!-- ===== LAUNCH SCREEN ===== -->
+  <sc-if value="{{ isLaunch }}" hint-placeholder-val="{{ true }}">
+    <div class="lsa-scroll" style="height:100vh;overflow-y:auto;display:flex;align-items:center;justify-content:center;padding:48px 24px;background:radial-gradient(1000px 560px at 50% -8%, #ffffff 0%, #eef1f6 62%);">
+      <div style="width:580px;max-width:100%;">
+
+        <div style="display:flex;flex-direction:column;align-items:center;text-align:center;margin-bottom:26px;">
+          <div style="width:46px;height:46px;border-radius:13px;background:{{ accent }};display:flex;align-items:center;justify-content:center;">
+            <div style="width:19px;height:19px;border:2.6px solid #fff;border-radius:50%;border-right-color:transparent;"></div>
+          </div>
+          <h1 style="font-weight:700;font-size:27px;letter-spacing:-.025em;margin:18px 0 0;">Live Session Assistant</h1>
+          <div style="font:600 11px/1 'IBM Plex Mono',monospace;letter-spacing:.16em;color:#8a93a8;margin-top:9px;">CLINICAL DECISION SUPPORT</div>
+          <p style="font-size:14px;line-height:1.6;color:#5e6a82;max-width:440px;margin:16px 0 0;">A real-time co-pilot for mental-health sessions. Open a patient to load their history and session context, then get grounded, in-the-moment decision support.</p>
+          <div style="display:inline-flex;align-items:center;gap:8px;margin-top:16px;padding:7px 13px;border:1px solid #f0d9d6;background:#fdf4f3;border-radius:20px;">
+            <span style="width:7px;height:7px;border-radius:50%;background:#c2362f;"></span>
+            <span style="font-size:12px;font-weight:600;color:#9c453f;">Decision support — not a diagnosis</span>
+          </div>
+        </div>
+
+        <div style="background:#fff;border:1px solid #dde3ee;border-radius:14px;padding:22px;box-shadow:0 12px 34px rgba(26,34,53,.06);">
+          <label style="display:block;font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.06em;color:#8a93a8;margin-bottom:9px;">PATIENT ID</label>
+          <div style="display:flex;gap:10px;">
+            <input value="{{ launchId }}" onInput="{{ onLaunchId }}" onKeyDown="{{ onLaunchKey }}" placeholder="e.g. PT-0042" style="flex:1;min-width:0;border:1px solid #dde3ee;border-radius:9px;padding:12px 13px;font:600 15px/1 'IBM Plex Mono',monospace;letter-spacing:.02em;color:#1a2235;outline:none;background:#fbfcfe;" />
+            <button onClick="{{ submitLaunch }}" style="cursor:pointer;border:none;background:{{ accent }};color:#fff;font-family:inherit;font-weight:600;font-size:14px;padding:0 20px;border-radius:9px;flex:none;">Open session</button>
+          </div>
+          <sc-if value="{{ hasLaunchError }}" hint-placeholder-val="{{ false }}">
+            <div style="margin-top:10px;font-size:12.5px;color:#b23a31;display:flex;align-items:center;gap:7px;"><span style="font-weight:700;">×</span>{{ launchError }}</div>
+          </sc-if>
+
+          <div style="display:flex;align-items:center;gap:12px;margin:20px 0 16px;">
+            <span style="flex:1;height:1px;background:#eef1f6;"></span>
+            <span style="font:500 10.5px/1 'IBM Plex Mono',monospace;color:#aab2c4;letter-spacing:.04em;">OR START WITH A DEMO PERSONA</span>
+            <span style="flex:1;height:1px;background:#eef1f6;"></span>
+          </div>
+
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">
+            <sc-for list="{{ personas }}" as="p" hint-placeholder-count="4">
+              <button onClick="{{ p.onClick }}" style="{{ p.style }}">
+                <div style="display:flex;align-items:center;justify-content:space-between;gap:6px;">
+                  <span style="font:600 13px/1 'IBM Plex Mono',monospace;color:#28304a;">{{ p.id }}</span>
+                  <span style="{{ p.metaStyle }}">{{ p.meta }}</span>
+                </div>
+                <div style="font-size:13px;font-weight:600;color:#3a4458;margin-top:9px;text-align:left;">{{ p.label }}</div>
+                <div style="font:500 11px/1 'IBM Plex Mono',monospace;color:#8a93a8;margin-top:5px;text-align:left;">{{ p.desc }}</div>
+              </button>
+            </sc-for>
+          </div>
+        </div>
+
+        <div style="background:#fff;border:1px solid #dde3ee;border-radius:14px;padding:16px 18px;margin-top:14px;">
+          <div style="font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.06em;color:#8a93a8;margin-bottom:10px;">RECENT PATIENTS</div>
+          <div style="display:flex;flex-direction:column;">
+            <sc-for list="{{ recents }}" as="r" hint-placeholder-count="3">
+              <button onClick="{{ r.onClick }}" style="{{ r.style }}">
+                <span style="font:600 13px/1 'IBM Plex Mono',monospace;color:#28304a;">{{ r.id }}</span>
+                <span style="font-size:12.5px;color:#647089;margin-left:12px;">{{ r.last }}</span>
+                <sc-if value="{{ r.flag }}" hint-placeholder-val="{{ false }}">
+                  <span style="margin-left:8px;display:inline-flex;align-items:center;gap:5px;padding:2px 7px;background:#fdeceb;border-radius:5px;"><span style="width:5px;height:5px;border-radius:50%;background:#c2362f;"></span><span style="font:600 9.5px/1 'IBM Plex Mono',monospace;color:#a8423b;">risk flag</span></span>
+                </sc-if>
+                <span style="margin-left:auto;color:#c2cad8;font-size:16px;">{{ r.arrow }}</span>
+              </button>
+            </sc-for>
+          </div>
+        </div>
+
+        <div style="text-align:center;margin-top:18px;font-size:11.5px;color:#9aa3b6;line-height:1.55;">Access is gated by a shared password when <span style="font-family:'IBM Plex Mono',monospace;">APP_PASSWORD</span> is configured. Use de-identified patient data only.</div>
+      </div>
+    </div>
+  </sc-if>
+
+  <!-- ===== SESSION ===== -->
+  <sc-if value="{{ isSession }}" hint-placeholder-val="{{ false }}">
+   <div style="height:100vh;display:flex;flex-direction:column;">
+  <!-- ===== HEADER ===== -->
+  <header style="height:62px;flex:none;display:flex;align-items:center;gap:18px;padding:0 22px;background:#fff;border-bottom:1px solid #dde3ee;z-index:5;">
+    <div onClick="{{ backToLaunch }}" title="Back to start" style="cursor:pointer;display:flex;align-items:center;gap:11px;">
+      <div style="width:30px;height:30px;border-radius:8px;background:{{ accent }};display:flex;align-items:center;justify-content:center;flex:none;">
+        <div style="width:13px;height:13px;border:2.2px solid #fff;border-radius:50%;border-right-color:transparent;"></div>
+      </div>
+      <div style="display:flex;flex-direction:column;line-height:1.05;">
+        <span style="font-weight:700;font-size:15px;letter-spacing:-.01em;">Live Session Assistant</span>
+        <span style="font:500 10.5px/1 'IBM Plex Mono',monospace;color:#8a93a8;letter-spacing:.04em;margin-top:3px;">CLINICAL DECISION SUPPORT</span>
+      </div>
+    </div>
+
+    <div style="display:flex;align-items:center;gap:8px;margin-left:6px;padding:5px 11px;background:#f4f6fa;border:1px solid #e3e8f2;border-radius:8px;">
+      <span style="font:500 11px/1 'IBM Plex Mono',monospace;color:#8a93a8;">PATIENT</span>
+      <span style="font:600 13px/1 'IBM Plex Mono',monospace;color:#1a2235;letter-spacing:.01em;">PT-0042</span>
+      <span style="width:6px;height:6px;border-radius:50%;background:#2f8f6b;margin-left:2px;box-shadow:0 0 0 3px rgba(47,143,107,.16);"></span>
+      <span style="font-size:11.5px;font-weight:600;color:#2f8f6b;">Session live</span>
+    </div>
+
+    <div style="margin-left:auto;display:flex;align-items:center;gap:16px;">
+      <div style="display:flex;align-items:center;gap:7px;">
+        <span style="font:500 10.5px/1 'IBM Plex Mono',monospace;color:#9aa3b6;">ELAPSED</span>
+        <span style="font:600 14px/1 'IBM Plex Mono',monospace;color:#1a2235;">{{ clock }}</span>
+      </div>
+      <div style="display:flex;align-items:center;gap:6px;padding:6px 11px;border:1px solid #f0d9d6;background:#fdf4f3;border-radius:8px;">
+        <span style="width:7px;height:7px;border-radius:50%;background:#c2362f;flex:none;"></span>
+        <span style="font-size:11.5px;font-weight:600;color:#9c453f;">Decision support — not a diagnosis</span>
+      </div>
+      <button onClick="{{ openReport }}" style="cursor:pointer;border:none;background:{{ accent }};color:#fff;font-family:inherit;font-weight:600;font-size:13px;padding:9px 15px;border-radius:8px;display:flex;align-items:center;gap:7px;">
+        End session &amp; report
+      </button>
+    </div>
+  </header>
+
+  <!-- ===== MAIN GRID ===== -->
+  <main style="flex:1;min-height:0;display:grid;grid-template-columns:316px minmax(380px,1fr) 404px;gap:14px;padding:14px;overflow-x:auto;">
+
+    <!-- ===== LEFT: PATIENT CONTEXT ===== -->
+    <section class="lsa-scroll" style="overflow-y:auto;min-height:0;display:flex;flex-direction:column;gap:14px;padding-right:4px;">
+
+      <div style="background:#fff;border:1px solid #dde3ee;border-radius:11px;padding:16px;">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:13px;">
+          <span style="width:3px;height:13px;border-radius:2px;background:{{ accent }};"></span>
+          <span style="font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.07em;color:#8a93a8;">PATIENT OVERVIEW</span>
+        </div>
+
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;">
+          <div>
+            <div style="font:600 19px/1 'IBM Plex Mono',monospace;letter-spacing:.01em;">PT-0042</div>
+            <div style="font-size:12.5px;color:#647089;margin-top:4px;">34 · returning patient</div>
+          </div>
+          <div style="display:flex;gap:8px;">
+            <div style="text-align:center;background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:7px 10px;">
+              <div style="font:600 17px/1 'IBM Plex Mono',monospace;">3</div>
+              <div style="font-size:9.5px;color:#8a93a8;margin-top:3px;letter-spacing:.02em;">SESSIONS</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="margin-top:15px;">
+          <div style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;margin-bottom:7px;">CLINICAL HISTORY</div>
+          <div style="display:flex;flex-wrap:wrap;gap:6px;">
+            <span style="font:500 11.5px/1 'IBM Plex Mono',monospace;background:#f0f3f9;color:#4a5670;padding:5px 8px;border-radius:6px;">generalized anxiety disorder</span>
+            <span style="font:500 11.5px/1 'IBM Plex Mono',monospace;background:#f0f3f9;color:#4a5670;padding:5px 8px;border-radius:6px;">panic attacks</span>
+          </div>
+        </div>
+
+        <div style="margin-top:14px;">
+          <div style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;margin-bottom:7px;">THERAPY GOALS</div>
+          <ul style="margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:6px;">
+            <li style="display:flex;gap:8px;font-size:13px;color:#3a4458;"><span style="color:{{ accent }};">›</span>reduce daily anxiety</li>
+            <li style="display:flex;gap:8px;font-size:13px;color:#3a4458;"><span style="color:{{ accent }};">›</span>manage panic episodes</li>
+          </ul>
+        </div>
+
+        <div style="margin-top:15px;padding-top:13px;border-top:1px dashed #e3e8f2;display:flex;justify-content:space-between;font-size:12px;">
+          <span style="color:#8a93a8;">Last seen</span>
+          <span style="font-weight:600;color:#3a4458;font-family:'IBM Plex Mono',monospace;">2026-05-28 · 25d ago</span>
+        </div>
+      </div>
+
+      <!-- HISTORY TIMELINE -->
+      <div style="background:#fff;border:1px solid #dde3ee;border-radius:11px;padding:16px;">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:14px;">
+          <span style="width:3px;height:13px;border-radius:2px;background:{{ accent }};"></span>
+          <span style="font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.07em;color:#8a93a8;">SESSION HISTORY</span>
+        </div>
+        <div style="display:flex;flex-direction:column;">
+          <sc-for list="{{ timeline }}" as="t" hint-placeholder-count="3">
+            <div style="display:grid;grid-template-columns:14px 1fr;gap:11px;">
+              <div style="display:flex;flex-direction:column;align-items:center;">
+                <span style="{{ t.dotStyle }}"></span>
+                <span style="{{ t.lineStyle }}"></span>
+              </div>
+              <div style="padding-bottom:14px;">
+                <div style="display:flex;align-items:center;justify-content:space-between;gap:6px;">
+                  <span style="font:600 12px/1 'IBM Plex Mono',monospace;color:#3a4458;">{{ t.date }}</span>
+                  <span style="font:600 11px/1 'IBM Plex Mono',monospace;{{ t.scoreStyle }}">{{ t.score }}</span>
+                </div>
+                <div style="display:flex;flex-wrap:wrap;gap:5px;margin-top:7px;">
+                  <sc-for list="{{ t.topics }}" as="tp" hint-placeholder-count="2">
+                    <span style="font:500 10.5px/1 'IBM Plex Mono',monospace;background:#eef1f6;color:#647089;padding:3px 6px;border-radius:5px;">{{ tp }}</span>
+                  </sc-for>
+                </div>
+                <sc-if value="{{ t.hasFlag }}" hint-placeholder-val="{{ false }}">
+                  <div style="display:inline-flex;align-items:center;gap:5px;margin-top:7px;padding:3px 7px;background:#fdeceb;border:1px solid #f3c9c5;border-radius:5px;">
+                    <span style="width:5px;height:5px;border-radius:50%;background:#c2362f;"></span>
+                    <span style="font:600 10px/1 'IBM Plex Mono',monospace;color:#a8423b;">{{ t.flagText }}</span>
+                  </div>
+                </sc-if>
+              </div>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <!-- DOCTOR NOTES -->
+      <div style="background:#fff;border:1px solid #dde3ee;border-radius:11px;padding:16px;">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:11px;">
+          <span style="width:3px;height:13px;border-radius:2px;background:{{ accent }};"></span>
+          <span style="font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.07em;color:#8a93a8;">CLINICIAN NOTES</span>
+        </div>
+        <textarea onInput="{{ onNotes }}" value="{{ notes }}" placeholder="Private notes for this session — saved automatically…" style="width:100%;min-height:90px;resize:vertical;border:1px solid #e3e8f2;border-radius:8px;padding:10px;font-family:inherit;font-size:13px;color:#1a2235;background:#fbfcfe;line-height:1.5;outline:none;"></textarea>
+      </div>
+    </section>
+
+    <!-- ===== CENTER: TRANSCRIPT ===== -->
+    <section style="min-height:0;display:flex;flex-direction:column;gap:14px;">
+
+      <sc-if value="{{ crisisActive }}" hint-placeholder-val="{{ false }}">
+        <div style="flex:none;background:#fbeceb;border:1.5px solid #e9b8b3;border-radius:11px;padding:14px 16px;animation:crisisPulse 2.2s ease-in-out infinite;">
+          <div style="display:flex;align-items:center;gap:10px;">
+            <div style="width:26px;height:26px;border-radius:7px;background:#c2362f;color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:15px;flex:none;">!</div>
+            <div style="display:flex;align-items:center;gap:9px;">
+              <span style="font-weight:700;font-size:14px;color:#9c2f29;">CRISIS PROTOCOL — {{ crisis.action }}</span>
+              <span style="font:600 11px/1 'IBM Plex Mono',monospace;background:#f3d4d1;color:#9c2f29;padding:4px 8px;border-radius:5px;">{{ crisis.flag_type }}</span>
+            </div>
+            <span style="margin-left:auto;font:500 10.5px/1 'IBM Plex Mono',monospace;color:#b07a76;">DETERMINISTIC · RULE-BASED · NOT LLM</span>
+          </div>
+          <p style="margin:10px 0 0;font-size:13px;line-height:1.55;color:#7a3a35;">{{ crisis.response }}</p>
+        </div>
+      </sc-if>
+
+      <div style="flex:1;min-height:0;background:#fff;border:1px solid #dde3ee;border-radius:11px;display:flex;flex-direction:column;overflow:hidden;">
+        <div style="flex:none;display:flex;align-items:center;gap:8px;padding:14px 18px;border-bottom:1px solid #eef1f6;">
+          <span style="width:3px;height:13px;border-radius:2px;background:{{ accent }};"></span>
+          <span style="font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.07em;color:#8a93a8;">LIVE TRANSCRIPT</span>
+          <span style="font-size:11.5px;color:#aab2c4;margin-left:2px;">two-channel · doctor &amp; patient</span>
+          <span style="margin-left:auto;font:500 11px/1 'IBM Plex Mono',monospace;color:#aab2c4;">{{ turnCount }} turns</span>
+        </div>
+
+        <div ref="{{ scrollRef }}" class="lsa-scroll" style="flex:1;min-height:0;overflow-y:auto;padding:18px;display:flex;flex-direction:column;gap:16px;">
+          <sc-for list="{{ msgViews }}" as="m" hint-placeholder-count="4">
+            <div style="{{ m.rowStyle }}">
+              <div style="display:flex;align-items:center;gap:8px;">
+                <span style="{{ m.labelStyle }}">{{ m.who }}</span>
+                <span style="font:500 10px/1 'IBM Plex Mono',monospace;color:#b4bccc;">{{ m.time }}</span>
+              </div>
+              <div style="{{ m.bubbleStyle }}">{{ m.text }}</div>
+              <sc-if value="{{ m.pending }}" hint-placeholder-val="{{ false }}">
+                <div style="display:flex;align-items:center;gap:7px;animation:softpulse 1.1s ease-in-out infinite;">
+                  <span style="width:6px;height:6px;border-radius:50%;background:#aab2c4;"></span>
+                  <span style="font:500 11px/1 'IBM Plex Mono',monospace;color:#aab2c4;">analyzing turn…</span>
+                </div>
+              </sc-if>
+              <sc-if value="{{ m.hasChips }}" hint-placeholder-val="{{ false }}">
+                <div style="display:flex;flex-wrap:wrap;gap:6px;">
+                  <sc-for list="{{ m.chips }}" as="c" hint-placeholder-count="3">
+                    <span style="{{ c.style }}">{{ c.text }}</span>
+                  </sc-for>
+                </div>
+              </sc-if>
+            </div>
+          </sc-for>
+        </div>
+
+        <!-- COMPOSER -->
+        <div style="flex:none;border-top:1px solid #eef1f6;padding:13px 16px;background:#fbfcfe;">
+          <div style="display:flex;align-items:flex-end;gap:10px;">
+            <div style="display:flex;background:#eef1f6;border-radius:8px;padding:3px;flex:none;">
+              <button onClick="{{ setSpeakerPatient }}" style="{{ patientTabStyle }}">Patient</button>
+              <button onClick="{{ setSpeakerDoctor }}" style="{{ doctorTabStyle }}">Doctor</button>
+            </div>
+            <textarea onInput="{{ onDraft }}" onKeyDown="{{ onComposerKey }}" value="{{ draft }}" placeholder="{{ composerPlaceholder }}" style="flex:1;min-height:42px;max-height:120px;resize:none;border:1px solid #dde3ee;border-radius:8px;padding:11px 12px;font-family:inherit;font-size:13.5px;color:#1a2235;outline:none;line-height:1.45;"></textarea>
+            <button onClick="{{ send }}" style="cursor:pointer;border:none;background:{{ accent }};color:#fff;font-family:inherit;font-weight:600;font-size:13px;height:42px;padding:0 16px;border-radius:8px;flex:none;">Log turn</button>
+          </div>
+          <div style="display:flex;align-items:center;gap:12px;margin-top:11px;">
+            <button onClick="{{ advance }}" style="{{ advanceStyle }}">
+              <span>▸ Advance scripted exchange</span>
+            </button>
+            <span style="font-size:11.5px;color:#9aa3b6;line-height:1.4;">{{ advanceHint }}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===== RIGHT: ASSISTANT ===== -->
+    <section class="lsa-scroll" style="overflow-y:auto;min-height:0;display:flex;flex-direction:column;gap:14px;padding-right:4px;">
+
+      <!-- PIPELINE -->
+      <sc-if value="{{ showPipeline }}" hint-placeholder-val="{{ true }}">
+        <div style="background:#172033;border:1px solid #172033;border-radius:11px;padding:15px 16px;color:#cdd6e8;">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:13px;">
+            <span style="width:3px;height:13px;border-radius:2px;background:#6f8fdc;"></span>
+            <span style="font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.07em;color:#8b97b4;">ANALYSIS PIPELINE</span>
+            <span style="{{ pipelineStatusStyle }}">{{ pipelineStatus }}</span>
+          </div>
+          <div style="display:flex;flex-direction:column;gap:3px;">
+            <sc-for list="{{ stages }}" as="s" hint-placeholder-count="6">
+              <div style="display:flex;align-items:center;gap:10px;padding:5px 0;">
+                <span style="{{ s.dotStyle }}">{{ s.icon }}</span>
+                <span style="{{ s.labelStyle }}">{{ s.label }}</span>
+                <span style="{{ s.subStyle }}">{{ s.sub }}</span>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+      </sc-if>
+
+      <!-- DECISION SUPPORT -->
+      <div style="background:#fff;border:1px solid #dde3ee;border-radius:11px;padding:16px;">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:14px;">
+          <span style="width:3px;height:13px;border-radius:2px;background:{{ accent }};"></span>
+          <span style="font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.07em;color:#8a93a8;">DECISION SUPPORT</span>
+        </div>
+
+        <sc-if value="{{ hasState }}" hint-placeholder-val="{{ true }}">
+          <div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:9px;padding:12px;margin-bottom:13px;">
+            <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px;">
+              <span style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;">LIKELY EMOTIONAL STATE</span>
+              <span style="{{ confStyle }}">{{ confLabel }}</span>
+            </div>
+            <div style="font-size:14px;font-weight:600;color:#28304a;line-height:1.4;">{{ stateText }}</div>
+          </div>
+        </sc-if>
+
+        <sc-if value="{{ hasRedFlags }}" hint-placeholder-val="{{ false }}">
+          <div style="margin-bottom:14px;">
+            <div style="display:flex;align-items:center;gap:7px;margin-bottom:8px;">
+              <span style="width:6px;height:6px;border-radius:2px;background:#c2362f;"></span>
+              <span style="font-size:11px;font-weight:700;color:#a8423b;letter-spacing:.02em;">RED FLAGS / CONCERNS</span>
+            </div>
+            <div style="display:flex;flex-direction:column;gap:7px;">
+              <sc-for list="{{ redFlags }}" as="r" hint-placeholder-count="2">
+                <div style="display:flex;gap:8px;background:#fdeceb;border:1px solid #f3c9c5;border-radius:8px;padding:9px 11px;font-size:12.5px;line-height:1.45;color:#8a3833;"><span style="color:#c2362f;font-weight:700;">›</span>{{ r }}</div>
+              </sc-for>
+            </div>
+          </div>
+        </sc-if>
+
+        <sc-if value="{{ hasMissing }}" hint-placeholder-val="{{ false }}">
+          <div style="margin-bottom:14px;">
+            <div style="font-size:11px;font-weight:700;color:#9a7a2a;letter-spacing:.02em;margin-bottom:8px;">MISSING INFO TO CLARIFY</div>
+            <div style="display:flex;flex-direction:column;gap:7px;">
+              <sc-for list="{{ missingInfo }}" as="mi" hint-placeholder-count="2">
+                <div style="display:flex;gap:8px;background:#fbf6e9;border:1px solid #efe1c0;border-radius:8px;padding:9px 11px;font-size:12.5px;line-height:1.45;color:#7a6420;"><span style="color:#b5862f;font-weight:700;">?</span>{{ mi }}</div>
+              </sc-for>
+            </div>
+          </div>
+        </sc-if>
+
+        <sc-if value="{{ hasQuestions }}" hint-placeholder-val="{{ true }}">
+          <div style="margin-bottom:14px;">
+            <div style="font-size:11px;font-weight:700;color:#3052b8;letter-spacing:.02em;margin-bottom:8px;">NEXT QUESTIONS TO CONSIDER</div>
+            <div style="display:flex;flex-direction:column;gap:8px;">
+              <sc-for list="{{ nextQuestions }}" as="q" hint-placeholder-count="2">
+                <div style="display:flex;gap:9px;background:#eef3fd;border:1px solid #d7e2fa;border-radius:8px;padding:10px 12px;font-size:12.5px;line-height:1.5;color:#2f3e63;"><span style="color:{{ accent }};font-weight:700;flex:none;">→</span>{{ q }}</div>
+              </sc-for>
+            </div>
+          </div>
+        </sc-if>
+
+        <sc-if value="{{ hasFollow }}" hint-placeholder-val="{{ false }}">
+          <div style="margin-bottom:6px;">
+            <div style="font-size:11px;font-weight:700;color:#647089;letter-spacing:.02em;margin-bottom:8px;">FOLLOW-UP POINTS</div>
+            <div style="display:flex;flex-direction:column;gap:6px;">
+              <sc-for list="{{ followUps }}" as="f" hint-placeholder-count="1">
+                <div style="display:flex;gap:8px;font-size:12.5px;line-height:1.45;color:#4a5670;"><span style="color:#aab2c4;">•</span>{{ f }}</div>
+              </sc-for>
+            </div>
+          </div>
+        </sc-if>
+
+        <sc-if value="{{ caveat }}" hint-placeholder-val="">
+          <div style="margin-top:10px;font-size:11.5px;font-style:italic;color:#9aa3b6;line-height:1.45;">Note: {{ caveat }}</div>
+        </sc-if>
+
+        <!-- WHY TOGGLE -->
+        <button onClick="{{ toggleWhy }}" style="{{ whyBtnStyle }}">
+          <span>{{ whyBtnLabel }}</span>
+          <span style="font:500 10px/1 'IBM Plex Mono',monospace;color:#9aa3b6;">grounding</span>
+        </button>
+
+        <sc-if value="{{ whyOpen }}" hint-placeholder-val="{{ false }}">
+          <div style="margin-top:11px;background:#f7f9fc;border:1px solid #e6eaf2;border-radius:9px;padding:13px;">
+            <div style="font-size:10px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:9px;">DRIVING SIGNALS</div>
+            <div style="display:flex;flex-direction:column;gap:6px;margin-bottom:13px;">
+              <sc-for list="{{ why.signals }}" as="sig" hint-placeholder-count="4">
+                <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;font-size:12px;">
+                  <span style="color:#647089;">{{ sig.k }}</span>
+                  <span style="font:600 11.5px/1 'IBM Plex Mono',monospace;color:#3a4458;">{{ sig.v }}</span>
+                </div>
+              </sc-for>
+            </div>
+            <sc-if value="{{ hasCases }}" hint-placeholder-val="{{ false }}">
+              <div style="font-size:10px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:9px;">RETRIEVED SIMILAR CASES (RAG)</div>
+              <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:13px;">
+                <sc-for list="{{ why.cases }}" as="cs" hint-placeholder-count="2">
+                  <div style="background:#fff;border:1px solid #e6eaf2;border-radius:7px;padding:9px 10px;">
+                    <div style="display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:5px;">
+                      <span style="font:600 9.5px/1 'IBM Plex Mono',monospace;color:#aab2c4;letter-spacing:.04em;">CORPUS · {{ cs.id }}</span>
+                      <span style="font:600 10px/1 'IBM Plex Mono',monospace;color:#2f8f6b;">{{ cs.sim }} match</span>
+                    </div>
+                    <div style="font-size:11.5px;color:#3a4458;line-height:1.4;margin-bottom:4px;">“{{ cs.q }}”</div>
+                    <div style="font-size:11px;color:#8a93a8;line-height:1.4;">{{ cs.a }}</div>
+                  </div>
+                </sc-for>
+              </div>
+            </sc-if>
+            <div style="font-size:10px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:7px;">CONTEXT SENT TO MODEL</div>
+            <pre style="margin:0;background:#172033;color:#aeb9d4;border-radius:7px;padding:10px;font:500 10.5px/1.5 'IBM Plex Mono',monospace;white-space:pre-wrap;word-break:break-word;">{{ why.context }}</pre>
+          </div>
+        </sc-if>
+
+        <div style="margin-top:14px;padding-top:12px;border-top:1px dashed #e3e8f2;font-size:11px;color:#9aa3b6;line-height:1.45;">Every item is grounded in the patient record, the live transcript, and retrieved cases. The assistant suggests — it never decides. Clinical judgment required.</div>
+      </div>
+
+      <!-- METRICS -->
+      <div style="background:#fff;border:1px solid #dde3ee;border-radius:11px;padding:16px;">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:14px;">
+          <span style="width:3px;height:13px;border-radius:2px;background:{{ accent }};"></span>
+          <span style="font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.07em;color:#8a93a8;">SESSION METRICS</span>
+        </div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:9px;margin-bottom:14px;">
+          <div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:10px;">
+            <div style="font-size:9.5px;color:#8a93a8;letter-spacing:.03em;margin-bottom:5px;">EMOTION</div>
+            <div style="font-weight:600;font-size:14px;color:#28304a;">{{ curEmotion }}</div>
+          </div>
+          <div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:10px;">
+            <div style="font-size:9.5px;color:#8a93a8;letter-spacing:.03em;margin-bottom:5px;">TOPIC</div>
+            <div style="font-weight:600;font-size:14px;color:#28304a;">{{ curTopic }}</div>
+          </div>
+        </div>
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:9px;">
+          <span style="font-size:11px;color:#8a93a8;">Sentiment trajectory</span>
+          <span style="{{ trajDeltaStyle }}">{{ trajDelta }}</span>
+        </div>
+        <sc-if value="{{ traj.has }}" hint-placeholder-val="{{ false }}">
+          <div style="background:#f7f9fc;border:1px solid #e6eaf2;border-radius:8px;padding:10px 6px 4px;">
+            <svg viewBox="0 0 240 60" preserveAspectRatio="none" style="width:100%;height:56px;display:block;">
+              <line x1="0" y1="30" x2="240" y2="30" stroke="#d9e0ec" stroke-width="1" stroke-dasharray="3 3"></line>
+              <polyline points="{{ traj.points }}" fill="none" stroke="{{ accent }}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"></polyline>
+            </svg>
+            <div style="display:flex;justify-content:space-between;font:500 9px/1 'IBM Plex Mono',monospace;color:#aab2c4;padding:0 4px;">
+              <span>turn 1</span><span>now</span>
+            </div>
+          </div>
+        </sc-if>
+      </div>
+    </section>
+  </main>
+   </div>
+  </sc-if>
+
+  <!-- ===== REPORT MODAL ===== -->
+  <sc-if value="{{ reportOpen }}" hint-placeholder-val="{{ false }}">
+    <div onClick="{{ closeReport }}" style="position:fixed;inset:0;background:rgba(16,22,38,.5);backdrop-filter:blur(2px);display:flex;align-items:center;justify-content:center;z-index:50;padding:24px;">
+      <div onClick="{{ stop }}" class="lsa-scroll" style="width:560px;max-width:100%;max-height:88vh;overflow-y:auto;background:#fff;border-radius:14px;box-shadow:0 24px 60px rgba(16,22,38,.35);">
+        <div style="position:sticky;top:0;background:#fff;padding:20px 24px 16px;border-bottom:1px solid #eef1f6;display:flex;align-items:center;justify-content:space-between;">
+          <div>
+            <div style="font-weight:700;font-size:17px;">End-of-session report</div>
+            <div style="font:500 11px/1 'IBM Plex Mono',monospace;color:#8a93a8;margin-top:5px;">PT-0042 · {{ clock }} · {{ turnCount }} turns logged</div>
+          </div>
+          <button onClick="{{ closeReport }}" style="cursor:pointer;border:1px solid #e3e8f2;background:#f4f6fa;width:30px;height:30px;border-radius:8px;font-size:16px;color:#647089;">×</button>
+        </div>
+        <div style="padding:20px 24px 24px;display:flex;flex-direction:column;gap:18px;">
+
+          <sc-if value="{{ report.hasFlags }}" hint-placeholder-val="{{ false }}">
+            <div style="background:#fbeceb;border:1px solid #e9b8b3;border-radius:10px;padding:13px 15px;">
+              <div style="font-size:11px;font-weight:700;color:#a8423b;letter-spacing:.03em;margin-bottom:8px;">RISK FLAGS RAISED</div>
+              <div style="display:flex;flex-direction:column;gap:6px;">
+                <sc-for list="{{ report.flags }}" as="rf" hint-placeholder-count="1">
+                  <div style="font-size:13px;color:#8a3833;display:flex;gap:7px;"><span style="font-weight:700;color:#c2362f;">!</span>{{ rf }}</div>
+                </sc-for>
+              </div>
+            </div>
+          </sc-if>
+
+          <div>
+            <div style="font-size:10.5px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:9px;">TOPICS DETECTED</div>
+            <div style="display:flex;flex-wrap:wrap;gap:6px;">
+              <sc-for list="{{ report.topics }}" as="rt" hint-placeholder-count="3">
+                <span style="font:500 11.5px/1 'IBM Plex Mono',monospace;background:#eef3fd;color:#3052b8;padding:6px 9px;border-radius:6px;">{{ rt }}</span>
+              </sc-for>
+            </div>
+          </div>
+
+          <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;">
+            <div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:9px;padding:12px;">
+              <div style="font-size:9.5px;color:#8a93a8;margin-bottom:6px;letter-spacing:.03em;">START SENTIMENT</div>
+              <div style="font:600 16px/1 'IBM Plex Mono',monospace;color:#28304a;">{{ report.startSent }}</div>
+            </div>
+            <div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:9px;padding:12px;">
+              <div style="font-size:9.5px;color:#8a93a8;margin-bottom:6px;letter-spacing:.03em;">END SENTIMENT</div>
+              <div style="font:600 16px/1 'IBM Plex Mono',monospace;color:#28304a;">{{ report.endSent }}</div>
+            </div>
+            <div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:9px;padding:12px;">
+              <div style="font-size:9.5px;color:#8a93a8;margin-bottom:6px;letter-spacing:.03em;">TURNS ANALYZED</div>
+              <div style="font:600 16px/1 'IBM Plex Mono',monospace;color:#28304a;">{{ report.analyzed }}</div>
+            </div>
+          </div>
+
+          <div>
+            <div style="font-size:10.5px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:9px;">CLINICIAN NOTES</div>
+            <div style="background:#fbfcfe;border:1px solid #e6eaf2;border-radius:9px;padding:12px;font-size:13px;line-height:1.55;color:#3a4458;white-space:pre-wrap;">{{ report.notes }}</div>
+          </div>
+
+          <div style="font-size:11px;color:#9aa3b6;line-height:1.5;border-top:1px dashed #e3e8f2;padding-top:14px;">This summary is decision support generated from session signals — not a diagnosis or medical record. Review, edit, and sign before filing. Crisis flags reflect a deterministic screen and require independent clinical assessment.</div>
+        </div>
+      </div>
+    </div>
+  </sc-if>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;showPipeline&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;},&quot;whyExpanded&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;},&quot;accent&quot;:{&quot;editor&quot;:&quot;color&quot;,&quot;default&quot;:&quot;#3563d4&quot;,&quot;tsType&quot;:&quot;string&quot;}}">
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this.scrollRef = React.createRef();
+    this._timer = null;
+    this._tick = null;
+
+    // ---- Scripted scenario (anxiety / panic, ending in a deterministic crisis) ----
+    this.PATIENT_ID = "PT-0042";
+
+    this.EX0 = {
+      doctor: "Good to see you. How have things been since we last met?",
+      patient: "Honestly, not great. The panic attacks came back this week — I had three.",
+      analysis: { emotion: "fear", emotionScore: 0.86, sentiment: "negative", sentimentScore: -0.54, topic: "anxiety", topicConf: 0.79 },
+      suggestions: {
+        emotional_state: "Heightened anxiety — panic recurrence after a calmer stretch",
+        state_confidence: "high",
+        red_flags: [],
+        missing_info: ["Frequency versus last month", "Any new stressors at work or home"],
+        next_questions: ["Consider asking what was happening right before each attack", "Consider asking how the attacks ended and what helped"],
+        follow_ups: ["Panic returned after improvement at the last two sessions — worth revisiting triggers"],
+        caveat: "Self-reported count; severity not yet assessed.",
+      },
+      why: {
+        signals: [
+          { k: "Emotion (DistilRoBERTa)", v: "fear · 86%" },
+          { k: "Sentiment (RoBERTa)", v: "negative · −0.54" },
+          { k: "Topic (BART zero-shot)", v: "anxiety · 79%" },
+          { k: "Crisis screen", v: "clear" },
+        ],
+        cases: [
+          { id: "q#118", sim: "91%", q: "My anxiety has been overwhelming and it comes in waves", a: "Grounding techniques — slow breathing, the 5-4-3-2-1 senses exercise — can help in the moment." },
+          { id: "q#073", sim: "88%", q: "I get panic attacks especially in the mornings", a: "Let's start by naming the feeling and noticing when it shows up." },
+        ],
+        context: "patient_id: PT-0042\nhistory: GAD; panic attacks\ngoals: reduce daily anxiety; manage panic\nLatest: panic attacks recurred — 3 this week\nTopic: anxiety (0.79) · Sentiment: negative (−0.54)",
+      },
+    };
+
+    this.SCRIPT = [
+      {
+        doctor: "I'm sorry they're back. What was going on right before they started?",
+        patient: "Work, mostly. My manager keeps piling things on, and I can't sleep — so I'm exhausted and on edge all day.",
+        analysis: { emotion: "anger", emotionScore: 0.61, sentiment: "negative", sentimentScore: -0.47, topic: "stress", topicConf: 0.72 },
+        suggestions: {
+          emotional_state: "Work stress and sleep loss appear to be driving the anxiety",
+          state_confidence: "high",
+          red_flags: [],
+          missing_info: ["Actual sleep duration and night wakings", "Caffeine or other substances used to cope"],
+          next_questions: ["Consider asking how many hours of sleep they're getting", "Consider asking whether setting limits with the manager feels possible"],
+          follow_ups: ["Connect the panic recurrence to workload and sleep deprivation"],
+          caveat: "",
+        },
+        why: {
+          signals: [
+            { k: "Emotion (DistilRoBERTa)", v: "anger · 61%" },
+            { k: "Sentiment (RoBERTa)", v: "negative · −0.47" },
+            { k: "Topic (BART zero-shot)", v: "stress · 72%" },
+            { k: "Crisis screen", v: "clear" },
+          ],
+          cases: [
+            { id: "q#204", sim: "87%", q: "Work stress is crushing me and I can't switch off", a: "Let's explore the thoughts underneath this feeling and gently test how accurate they are." },
+            { id: "q#155", sim: "82%", q: "I lie awake for hours and wake up exhausted", a: "A consistent sleep schedule and a wind-down routine (no screens an hour before bed) often help." },
+          ],
+          context: "patient_id: PT-0042\nHistory: GAD; panic attacks\nLatest: panic triggered by workload; sleeping poorly; on edge\nTopic: stress (0.72) · Sentiment: negative (−0.47)",
+        },
+      },
+      {
+        doctor: "That exhaustion sounds relentless. How many hours are you actually sleeping?",
+        patient: "Three, maybe four. Honestly, lately I've been thinking there's no point in living anymore.",
+        crisis: {
+          flag_type: "suicide_risk",
+          action: "CRITICAL",
+          response: "A crisis indicator was detected in the patient's words. Prioritise immediate safety: stay present, assess risk directly, and share the 988 Suicide & Crisis Lifeline — patients can call or text 988. This screen is rule-based and fired independently of the language model.",
+        },
+        analysis: { emotion: "sadness", emotionScore: 0.80, sentiment: "negative", sentimentScore: -0.89, topic: "depression", topicConf: 0.68 },
+        suggestions: {
+          emotional_state: "Hopelessness with passive suicidal ideation",
+          state_confidence: "high",
+          red_flags: ["Passive suicidal ideation expressed — \u201cno point in living\u201d", "Severe sleep deprivation (3–4 hrs) compounding risk"],
+          missing_info: ["Presence of a specific plan, means, or intent", "Protective factors and who is at home tonight"],
+          next_questions: ["Consider gently and directly asking whether they've had thoughts of ending their life, and whether there is a plan", "Consider asking what has helped them stay safe so far"],
+          follow_ups: ["Shift from the agenda to a risk assessment; revisit panic and sleep once safety is established"],
+          caveat: "The deterministic crisis screen fired independently of the model.",
+        },
+        why: {
+          signals: [
+            { k: "Emotion (DistilRoBERTa)", v: "sadness · 80%" },
+            { k: "Sentiment (RoBERTa)", v: "negative · −0.89" },
+            { k: "Topic (BART zero-shot)", v: "depression · 68%" },
+            { k: "Crisis screen", v: "suicide_risk · CRITICAL" },
+          ],
+          cases: [
+            { id: "q#031", sim: "90%", q: "I feel empty and hopeless and I don't see the point", a: "Reaching out for support — a trusted person or a professional — is a strength, not a weakness." },
+          ],
+          context: "patient_id: PT-0042\nLatest: 3–4 hrs sleep; \u201cno point in living anymore\u201d\nCRISIS SCREEN: suicide_risk (CRITICAL) — deterministic\nTopic: depression (0.68) · Sentiment: negative (−0.89)",
+        },
+      },
+    ];
+
+    const now = this.fmtTime();
+    this.state = {
+      messages: [
+        { id: "m0", speaker: "doctor", text: this.EX0.doctor, time: now },
+        { id: "m1", speaker: "patient", text: this.EX0.patient, time: now, analysis: this.EX0.analysis },
+      ],
+      suggestions: this.EX0.suggestions,
+      why: this.EX0.why,
+      whyOpen: null,
+      scriptIndex: 0,
+      speaker: "patient",
+      draft: "",
+      notes: "",
+      crisisActive: null,
+      reportOpen: false,
+      view: "launch",
+      launchId: "PT-0042",
+      launchError: "",
+      trajectory: [-0.54],
+      elapsed: 0,
+      stages: this.doneStages(false),
+      running: false,
+    };
+  }
+
+  // ---------- lifecycle ----------
+  componentDidMount() {
+    try {
+      const n = localStorage.getItem("lsa-doctor-notes");
+      if (n) this.setState({ notes: n });
+      let start = localStorage.getItem("lsa-session-start");
+      if (!start) { start = String(Date.now()); localStorage.setItem("lsa-session-start", start); }
+      this._start = parseInt(start, 10);
+    } catch (e) { this._start = Date.now(); }
+    this._tick = setInterval(() => {
+      this.setState({ elapsed: Math.floor((Date.now() - this._start) / 1000) });
+    }, 1000);
+    // ---- Streamlit bridge: announce readiness and receive real pipeline results ----
+    window.__lsaApply = (args) => this.applyServerArgs(args);
+    if (window.Streamlit) {
+      try {
+        window.Streamlit.setComponentReady();
+        window.Streamlit.setFrameHeight(Math.max(900, window.innerHeight || 900));
+        if (window.__lsaPendingArgs) this.applyServerArgs(window.__lsaPendingArgs);
+      } catch (e) {}
+    }
+  }
+  componentWillUnmount() {
+    if (this._timer) clearTimeout(this._timer);
+    if (this._tick) clearInterval(this._tick);
+  }
+  componentDidUpdate() {
+    const el = this.scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }
+
+  // ---------- helpers ----------
+  fmtTime() {
+    const d = new Date();
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+  uid() { return "m" + Math.random().toString(36).slice(2, 9); }
+  cap(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : ""; }
+  hexRgba(hex, a) {
+    const h = (hex || "#3563d4").replace("#", "");
+    const r = parseInt(h.slice(0, 2), 16), g = parseInt(h.slice(2, 4), 16), b = parseInt(h.slice(4, 6), 16);
+    return `rgba(${r},${g},${b},${a})`;
+  }
+  fmtScore(n) { return (n >= 0 ? "+" : "") + n.toFixed(2); }
+
+  doneStages(isCrisis) {
+    return this.stageDefs().map((s, i) => ({ ...s, status: (i === 0 && isCrisis) ? "alert" : "done" }));
+  }
+  stageDefs() {
+    return [
+      { key: "safety", label: "Crisis screen", sub: "regex · deterministic" },
+      { key: "emotion", label: "Emotion / urgency", sub: "DistilRoBERTa" },
+      { key: "sentiment", label: "Sentiment", sub: "RoBERTa 3-class" },
+      { key: "topic", label: "Topic", sub: "BART zero-shot" },
+      { key: "retrieval", label: "Semantic retrieval", sub: "MiniLM · Pinecone" },
+      { key: "generate", label: "Generating guidance", sub: "Groq · llama-3.3-70b" },
+    ];
+  }
+
+  // deterministic crisis screen, ported from safety.py
+  checkSafety(text) {
+    const t = (text || "").toLowerCase();
+    const rules = [
+      { rx: /\b(suicide|suicidal|kill myself|killing myself|end it all|end my life|ending my life|take my life|take my own life|want to die|wanting to die|better off dead|don'?t want to live|don'?t want to be alive|no reason to live|no point in living)\b/, flag: "suicide_risk", action: "CRITICAL", response: "A crisis indicator was detected. Prioritise immediate safety and share the 988 Suicide & Crisis Lifeline — call or text 988. Rule-based screen, fired independently of the model." },
+      { rx: /\b((harm|harming|hurt|hurting|kill|killing|cut|cutting) (myself|himself|herself|themselves|others|someone|him|her|them)|self[- ]?harm)\b/, flag: "violence_risk", action: "CRITICAL", response: "Safety is the immediate priority. If anyone is in danger right now, contact emergency services (911). You can also reach the 988 Lifeline by calling or texting 988." },
+      { rx: /\b(abuse|abused|abusing|abuser|molest|molested|molesting|rape|raped|raping|rapist|sexual assault|sexually assaulted)\b/, flag: "abuse_disclosure", action: "URGENT", response: "Thank the patient for sharing. Connect them with a specialist who can help, and follow your safeguarding protocol." },
+    ];
+    const sev = { CRITICAL: 2, URGENT: 1 };
+    let best = null, rank = -1;
+    for (const r of rules) {
+      if (r.rx.test(t) && sev[r.action] > rank) { rank = sev[r.action]; best = { flag_type: r.flag, action: r.action, response: r.response }; }
+    }
+    return best;
+  }
+
+  buildGeneric(text, crisis) {
+    const neg = /(can'?t|hopeless|worthless|anxious|panic|scared|terrified|tired|exhausted|sad|angry|alone|overwhelmed|stress|worry|worried|cry|hurt|empty|nothing|afraid|fear)/i.test(text);
+    const sentiment = crisis ? "negative" : (neg ? "negative" : "neutral");
+    const score = crisis ? -0.85 : (neg ? -0.45 : 0.06);
+    const emotion = crisis ? "sadness" : (neg ? "fear" : "neutral");
+    const topic = /sleep|insomnia|awake/i.test(text) ? "sleep-improvement" : /work|job|manager|boss/i.test(text) ? "stress" : /panic|anx|worry/i.test(text) ? "anxiety" : /sad|empty|hopeless|down/i.test(text) ? "depression" : "general";
+    const analysis = { emotion, emotionScore: crisis ? 0.81 : (neg ? 0.6 : 0.42), sentiment, sentimentScore: score, topic, topicConf: 0.61 };
+    const suggestions = crisis ? {
+      emotional_state: "Elevated risk — see safety protocol above",
+      state_confidence: "high",
+      red_flags: ["Crisis language detected — " + crisis.flag_type.replace(/_/g, " ")],
+      missing_info: ["Presence of a plan, means, or intent", "Immediate safety and support tonight"],
+      next_questions: ["Consider asking directly about thoughts of self-harm and any plan", "Consider asking what has kept them safe so far"],
+      follow_ups: ["Prioritise risk assessment before continuing the agenda"],
+      caveat: "The deterministic crisis screen fired independently of the model.",
+    } : {
+      emotional_state: neg ? "Distress / low mood" : "Neutral / settled",
+      state_confidence: neg ? "medium" : "low",
+      red_flags: [],
+      missing_info: ["More detail on when this started and how often it happens"],
+      next_questions: ["Consider asking the patient to say more about that", "Consider asking how it affects daily life and sleep"],
+      follow_ups: neg ? ["Note this theme to revisit later in the session"] : [],
+      caveat: "",
+    };
+    const why = {
+      signals: [
+        { k: "Emotion (DistilRoBERTa)", v: emotion + " · " + Math.round(analysis.emotionScore * 100) + "%" },
+        { k: "Sentiment (RoBERTa)", v: sentiment + " · " + this.fmtScore(score) },
+        { k: "Topic (BART zero-shot)", v: topic + " · 61%" },
+        { k: "Crisis screen", v: crisis ? crisis.flag_type + " · " + crisis.action : "clear" },
+      ],
+      cases: [],
+      context: "patient_id: PT-0042\nLatest transcript turn analyzed against the patient record and retrieved cases.\nTopic: " + topic + " · Sentiment: " + sentiment + " (" + this.fmtScore(score) + ")",
+    };
+    return { analysis, suggestions, why, crisis: crisis || null };
+  }
+
+  // ---------- pipeline ----------
+  runPipeline(payload) {
+    if (this._timer) clearTimeout(this._timer);
+    const stages = this.stageDefs().map(s => ({ ...s, status: "pending" }));
+    const isCrisis = !!payload.crisis;
+    this.setState({ stages, suggestions: null, why: null, whyOpen: null, running: true });
+
+    const advance = (idx) => {
+      if (idx >= stages.length) { this.finishPipeline(payload); return; }
+      this.setState(s => {
+        const st = s.stages.slice(); st[idx] = { ...st[idx], status: "running" }; return { stages: st };
+      });
+      this._timer = setTimeout(() => {
+        this.setState(s => {
+          const st = s.stages.slice();
+          const status = (st[idx].key === "safety" && isCrisis) ? "alert" : "done";
+          st[idx] = { ...st[idx], status }; return { stages: st };
+        });
+        if (stages[idx].key === "safety" && isCrisis) this.setState({ crisisActive: payload.crisis });
+        advance(idx + 1);
+      }, 300);
+    };
+    advance(0);
+  }
+
+  finishPipeline(payload) {
+    this.setState(s => {
+      const msgs = s.messages.slice();
+      for (let j = msgs.length - 1; j >= 0; j--) {
+        if (msgs[j].speaker === "patient" && msgs[j].pending) {
+          msgs[j] = { ...msgs[j], pending: false, analysis: payload.analysis, crisis: payload.crisis || null };
+          break;
+        }
+      }
+      return {
+        messages: msgs,
+        suggestions: payload.suggestions,
+        why: payload.why,
+        running: false,
+        trajectory: s.trajectory.concat([payload.analysis.sentimentScore]),
+      };
+    });
+  }
+
+  // ---------- actions ----------
+  advance = () => {
+    if (this.state.running) return;
+    const step = this.SCRIPT[this.state.scriptIndex];
+    if (!step) return;
+    const now = this.fmtTime();
+    this.setState(s => ({
+      messages: s.messages.concat([
+        { id: this.uid(), speaker: "doctor", text: step.doctor, time: now },
+        { id: this.uid(), speaker: "patient", text: step.patient, time: now, pending: true },
+      ]),
+      scriptIndex: s.scriptIndex + 1,
+    }));
+    setTimeout(() => this.runPipeline(step), 60);
+  };
+
+  send = () => {
+    if (this.state.running) return;
+    const text = this.state.draft.trim();
+    if (!text) return;
+    const now = this.fmtTime();
+    if (this.state.speaker === "doctor") {
+      this.setState(s => ({ messages: s.messages.concat([{ id: this.uid(), speaker: "doctor", text, time: now }]), draft: "" }));
+      return;
+    }
+    // Patient turn: route to the REAL Python pipeline via the Streamlit bridge.
+    const nonce = (this._nonce = (this._nonce || 0) + 1);
+    this._pendingNonce = nonce;
+    const transcript = this.state.messages.concat([{ speaker: "patient", text }])
+      .map(m => this.cap(m.speaker) + ": " + m.text).join("\n");
+    this.setState(s => ({
+      messages: s.messages.concat([{ id: this.uid(), speaker: "patient", text, time: now, pending: true }]),
+      draft: "",
+      stages: this.stageDefs().map(x => ({ ...x, status: "pending" })),
+      suggestions: null, why: null, whyOpen: null, running: true,
+    }));
+    if (window.Streamlit && window.Streamlit.setComponentValue) {
+      window.Streamlit.setComponentValue({ nonce: nonce, kind: "patient_turn", text: text, transcript: transcript });
+    } else {
+      // Fallback to the local mock pipeline when opened outside Streamlit.
+      const crisis = this.checkSafety(text);
+      setTimeout(() => this.runPipeline(this.buildGeneric(text, crisis)), 60);
+    }
+  };
+
+  // Apply a real pipeline result pushed from Python (matched by nonce).
+  applyServerArgs(args) {
+    if (!args || !args.result) return;
+    const r = args.result;
+    if (r.nonce == null || r.nonce !== this._pendingNonce) return;
+    this._pendingNonce = null;
+    const isCrisis = !!r.crisis;
+    this.setState({ stages: this.doneStages(isCrisis), crisisActive: r.crisis || this.state.crisisActive });
+    this.finishPipeline({ analysis: r.analysis, suggestions: r.suggestions, why: r.why, crisis: r.crisis || null });
+  }
+
+  onComposerKey = (e) => {
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); this.send(); }
+  };
+  onDraft = (e) => this.setState({ draft: e.target.value });
+  onNotes = (e) => {
+    const v = e.target.value;
+    this.setState({ notes: v });
+    try { localStorage.setItem("lsa-doctor-notes", v); } catch (err) {}
+  };
+  setSpeakerPatient = () => this.setState({ speaker: "patient" });
+  setSpeakerDoctor = () => this.setState({ speaker: "doctor" });
+  toggleWhy = () => this.setState(s => ({ whyOpen: !this.whyEffective() }));
+  openReport = () => this.setState({ reportOpen: true });
+  closeReport = () => this.setState({ reportOpen: false });
+  stop = (e) => { e.stopPropagation(); };
+
+  openSession = () => {
+    this._start = Date.now();
+    try { localStorage.setItem("lsa-session-start", String(this._start)); } catch (e) {}
+    this.setState({ view: "session", elapsed: 0, launchError: "" });
+  };
+  submitLaunch = () => {
+    const id = (this.state.launchId || "").trim().toUpperCase();
+    if (id === "PT-0042") this.openSession();
+    else this.setState({ launchError: id ? `No scripted scenario for ${id} in this prototype — try PT-0042.` : "Enter a patient ID to continue." });
+  };
+  seededNote = () => this.setState({ launchError: "Only PT-0042 has a scripted scenario in this prototype. The other patients are seeded for the real app." });
+  onLaunchId = (e) => this.setState({ launchId: e.target.value, launchError: "" });
+  onLaunchKey = (e) => { if (e.key === "Enter") { e.preventDefault(); this.submitLaunch(); } };
+  backToLaunch = () => this.setState({ view: "launch" });
+
+  whyEffective() {
+    if (this.state.whyOpen === null) return !!(this.props.whyExpanded);
+    return this.state.whyOpen;
+  }
+
+  // ---------- render ----------
+  renderVals() {
+    const accent = this.props.accent ?? "#3563d4";
+    const accentSoft = this.hexRgba(accent, 0.1);
+
+    // ---- launch screen: personas + recents ----
+    const pStyle = (en) => `cursor:pointer;text-align:left;border:${en ? "1.5px solid " + accent : "1px solid #e6eaf2"};background:${en ? accentSoft : "#fbfcfe"};border-radius:11px;padding:13px;font-family:inherit;${en ? "" : "opacity:.82;"}`;
+    const pMeta = (en) => `font:600 9px/1 'IBM Plex Mono',monospace;letter-spacing:.04em;padding:3px 7px;border-radius:5px;${en ? `background:${accent};color:#fff;` : "background:#eef1f6;color:#8a93a8;"}`;
+    const personas = [
+      { id: "PT-0042", label: "Anxiety & panic", desc: "GAD · panic attacks", meta: "demo ready", en: true },
+      { id: "PT-0017", label: "Depression", desc: "MDD · low mood", meta: "seeded", en: false },
+      { id: "PT-0008", label: "Grief & loss", desc: "recent bereavement", meta: "seeded", en: false },
+      { id: "PT-0023", label: "Trauma / PTSD", desc: "hypervigilance", meta: "seeded", en: false },
+    ].map(p => ({ ...p, style: pStyle(p.en), metaStyle: pMeta(p.en), onClick: p.en ? this.openSession : this.seededNote }));
+    const recents = [
+      { id: "PT-0042", last: "today · panic recurrence", flag: false, en: true },
+      { id: "PT-0031", last: "2026-06-12 · routine review", flag: false, en: false },
+      { id: "PT-0009", last: "2026-06-05 · risk flagged", flag: true, en: false },
+    ].map(r => ({ ...r, style: `cursor:pointer;display:flex;align-items:center;width:100%;text-align:left;border:none;background:transparent;padding:10px 6px;font-family:inherit;${r.en ? "" : "opacity:.72;"}`, onClick: r.en ? this.openSession : this.seededNote, arrow: r.en ? "›" : "" }));
+    const sg = this.state.suggestions || {};
+    const s = this.state;
+
+    // clock
+    const mm = String(Math.floor(s.elapsed / 60)).padStart(2, "0");
+    const ss = String(s.elapsed % 60).padStart(2, "0");
+
+    // messages
+    const chip = (text, bg, color) => ({ text, style: `font:500 10.5px/1 'IBM Plex Mono',monospace;padding:4px 7px;border-radius:5px;background:${bg};color:${color};letter-spacing:.02em;` });
+    const msgViews = s.messages.map(m => {
+      const isP = m.speaker === "patient";
+      const isCrisisMsg = !!m.crisis;
+      const bubbleBase = "font-size:13.5px;line-height:1.55;padding:11px 13px;border-radius:10px;max-width:88%;";
+      let bubbleStyle, labelStyle;
+      if (!isP) {
+        bubbleStyle = bubbleBase + "background:#f4f6fa;border:1px solid #e6eaf2;color:#2a3450;border-top-left-radius:3px;";
+        labelStyle = "font:600 10px/1 'IBM Plex Mono',monospace;letter-spacing:.05em;color:#8a93a8;text-transform:uppercase;";
+      } else if (isCrisisMsg) {
+        bubbleStyle = bubbleBase + "background:#fbeceb;border:1px solid #e9b8b3;color:#7a3a35;border-top-left-radius:3px;";
+        labelStyle = "font:600 10px/1 'IBM Plex Mono',monospace;letter-spacing:.05em;color:#c2362f;text-transform:uppercase;";
+      } else {
+        bubbleStyle = bubbleBase + "background:#eef3fd;border:1px solid #d7e2fa;color:#26365e;border-top-left-radius:3px;";
+        labelStyle = `font:600 10px/1 'IBM Plex Mono',monospace;letter-spacing:.05em;color:${accent};text-transform:uppercase;`;
+      }
+      const chips = [];
+      if (m.analysis) {
+        const a = m.analysis;
+        chips.push(chip(this.cap(a.emotion) + " · " + Math.round(a.emotionScore * 100) + "%", "#fbf3e4", "#8a6a1f"));
+        const neg = a.sentimentScore < -0.05, pos = a.sentimentScore > 0.05;
+        chips.push(chip(this.fmtScore(a.sentimentScore), neg ? "#fdeceb" : pos ? "#e8f5ef" : "#eef1f6", neg ? "#b23a31" : pos ? "#2f8f6b" : "#647089"));
+        chips.push(chip(a.topic, "#eaf0fd", "#3052b8"));
+      }
+      return {
+        id: m.id, who: isP ? "Patient" : "Doctor", time: m.time, text: m.text,
+        rowStyle: "display:flex;flex-direction:column;gap:7px;animation:fadeUp .3s ease;",
+        labelStyle, bubbleStyle,
+        pending: !!m.pending, hasChips: chips.length > 0, chips,
+      };
+    });
+
+    // timeline (prior sessions)
+    const tlRaw = [
+      { date: "2026-05-28", topics: ["anxiety", "sleep-improvement"], score: -0.42, flag: null },
+      { date: "2026-04-30", topics: ["stress", "anxiety"], score: -0.61, flag: null },
+      { date: "2026-03-18", topics: ["anxiety", "panic"], score: -0.78, flag: "suicide_risk" },
+    ];
+    const timeline = tlRaw.map((t, i) => ({
+      date: t.date, topics: t.topics, score: this.fmtScore(t.score),
+      scoreStyle: `color:${t.score < -0.6 ? "#b23a31" : t.score < -0.3 ? "#b5862f" : "#647089"};`,
+      dotStyle: `width:10px;height:10px;border-radius:50%;flex:none;margin-top:3px;background:${t.flag ? "#c2362f" : i === 0 ? accent : "#c2cad8"};`,
+      lineStyle: i === tlRaw.length - 1 ? "display:none;" : "flex:1;width:1.5px;background:#e6eaf2;margin:3px 0;",
+      hasFlag: !!t.flag, flagText: t.flag ? "risk: " + t.flag : "",
+    }));
+
+    // pipeline stage views
+    const stageStyle = (st) => {
+      const map = {
+        pending: { dot: "background:#26314c;color:#5d6b8a;border:1px solid #2c3852;", label: "color:#6b7793;", icon: "" },
+        running: { dot: `background:#6f8fdc;color:#fff;border:1px solid #6f8fdc;`, label: "color:#e6ecf8;font-weight:600;", icon: "spin" },
+        done: { dot: "background:#2f8f6b;color:#fff;border:1px solid #2f8f6b;", label: "color:#cdd6e8;", icon: "✓" },
+        alert: { dot: "background:#c2362f;color:#fff;border:1px solid #c2362f;", label: "color:#f0c4c0;font-weight:600;", icon: "!" },
+      };
+      return map[st] || map.pending;
+    };
+    const stages = s.stages.map(st => {
+      const v = stageStyle(st.status);
+      const spinning = v.icon === "spin";
+      return {
+        label: st.label, sub: st.sub,
+        icon: spinning ? "" : v.icon,
+        dotStyle: `width:18px;height:18px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;font:700 10px/1 'IBM Plex Mono',monospace;${v.dot}` + (spinning ? "border-right-color:transparent;animation:spin .7s linear infinite;" : ""),
+        labelStyle: `font-size:12.5px;${v.label}`,
+        subStyle: "font:500 10px/1 'IBM Plex Mono',monospace;color:#5c6885;margin-left:auto;",
+      };
+    });
+    const pStatus = s.running ? "RUNNING" : "READY";
+    const pipelineStatusStyle = `margin-left:auto;font:600 9.5px/1 'IBM Plex Mono',monospace;letter-spacing:.06em;padding:3px 7px;border-radius:5px;${s.running ? "background:#2a3a63;color:#9fb6f0;" : "background:#1f4a3a;color:#7fd6b0;"}`;
+
+    // confidence pill
+    const conf = (sg.state_confidence || "low");
+    const confMap = { high: ["#e8f5ef", "#2f8f6b", "high confidence"], medium: ["#fbf6e9", "#b5862f", "medium confidence"], low: ["#eef1f6", "#8a93a8", "low — treat as a hint"] };
+    const cm = confMap[conf] || confMap.low;
+
+    // trajectory sparkline
+    const tr = s.trajectory;
+    let trajPoints = "", trajHas = tr.length >= 2;
+    if (trajHas) {
+      const n = tr.length;
+      trajPoints = tr.map((v, i) => {
+        const x = (i / (n - 1)) * 240;
+        const y = 30 - (v * 26); // v in [-1,1] -> [56,4]
+        return `${x.toFixed(1)},${Math.max(4, Math.min(56, y)).toFixed(1)}`;
+      }).join(" ");
+    }
+    const tDelta = tr.length >= 2 ? tr[tr.length - 1] - tr[0] : 0;
+    const trajDelta = (tr.length >= 2 ? (tDelta >= 0 ? "▲ +" : "▼ ") + tDelta.toFixed(2) : "—");
+    const trajDeltaStyle = `font:600 11px/1 'IBM Plex Mono',monospace;color:${tDelta > 0.02 ? "#2f8f6b" : tDelta < -0.02 ? "#b23a31" : "#8a93a8"};`;
+
+    // current metrics from last analyzed patient message
+    let curEmotion = "—", curTopic = "—";
+    for (let j = s.messages.length - 1; j >= 0; j--) {
+      if (s.messages[j].analysis) { curEmotion = this.cap(s.messages[j].analysis.emotion); curTopic = s.messages[j].analysis.topic; break; }
+    }
+
+    // composer / speaker tabs
+    const tabBase = "cursor:pointer;border:none;font-family:inherit;font-weight:600;font-size:12px;padding:7px 13px;border-radius:6px;";
+    const patientTabStyle = tabBase + (s.speaker === "patient" ? `background:${accent};color:#fff;` : "background:transparent;color:#7a849c;");
+    const doctorTabStyle = tabBase + (s.speaker === "doctor" ? `background:${accent};color:#fff;` : "background:transparent;color:#7a849c;");
+    const composerPlaceholder = s.speaker === "patient" ? "Log the patient's words… (try a phrase like \u201cI don't want to live\u201d)" : "Log your question to the patient…";
+
+    // advance button
+    const scriptDone = this.state.scriptIndex >= this.SCRIPT.length;
+    const advanceStyle = `cursor:${scriptDone || s.running ? "default" : "pointer"};border:1px solid ${scriptDone ? "#e3e8f2" : this.hexRgba(accent, 0.35)};background:${scriptDone ? "#f4f6fa" : accentSoft};color:${scriptDone ? "#aab2c4" : accent};font-family:inherit;font-weight:600;font-size:12.5px;padding:8px 13px;border-radius:8px;flex:none;`;
+    const advanceHint = scriptDone ? "Scripted arc complete — keep typing to continue; patient turns are screened live." : "Plays the next doctor↔patient exchange and runs the full analysis pipeline.";
+
+    // why
+    const whyOpen = this.whyEffective();
+    const why = s.why || { signals: [], cases: [], context: "" };
+    const whyBtnStyle = "cursor:pointer;width:100%;margin-top:14px;display:flex;align-items:center;justify-content:space-between;gap:8px;border:1px solid #e3e8f2;background:#fbfcfe;border-radius:8px;padding:10px 12px;font-family:inherit;font-size:12.5px;font-weight:600;color:#4a5670;";
+
+    // report
+    let report = { topics: [], flags: [], hasFlags: false, startSent: "—", endSent: "—", analyzed: 0, notes: "(no notes added)" };
+    if (s.reportOpen) {
+      const topics = []; const flags = []; let analyzed = 0;
+      s.messages.forEach(m => {
+        if (m.analysis) { analyzed++; if (!topics.includes(m.analysis.topic)) topics.push(m.analysis.topic); }
+        if (m.crisis) flags.push(m.crisis.flag_type.replace(/_/g, " ") + " — " + m.crisis.action + " (deterministic screen)");
+      });
+      report = {
+        topics: topics.length ? topics : ["—"],
+        flags, hasFlags: flags.length > 0,
+        startSent: tr.length ? this.fmtScore(tr[0]) : "—",
+        endSent: tr.length ? this.fmtScore(tr[tr.length - 1]) : "—",
+        analyzed,
+        notes: s.notes.trim() || "(no notes added)",
+      };
+    }
+
+    return {
+      accent, accentSoft,
+      isLaunch: s.view === "launch", isSession: s.view === "session",
+      launchId: s.launchId, launchError: s.launchError, hasLaunchError: !!s.launchError,
+      personas, recents,
+      submitLaunch: this.submitLaunch, onLaunchId: this.onLaunchId, onLaunchKey: this.onLaunchKey, backToLaunch: this.backToLaunch,
+      clock: `${mm}:${ss}`,
+      msgViews, timeline,
+      turnCount: s.messages.length, turns: s.messages.length,
+      stages, pipelineStatus: pStatus, pipelineStatusStyle,
+      showPipeline: this.props.showPipeline ?? true,
+      crisisActive: s.crisisActive, crisis: s.crisisActive || { action: "", flag_type: "", response: "" },
+
+      // suggestions
+      hasState: !!sg.emotional_state, stateText: sg.emotional_state || "",
+      confLabel: cm[2], confStyle: `font:600 9.5px/1 'IBM Plex Mono',monospace;letter-spacing:.03em;padding:4px 7px;border-radius:5px;background:${cm[0]};color:${cm[1]};`,
+      hasRedFlags: (sg.red_flags || []).length > 0, redFlags: sg.red_flags || [],
+      hasMissing: (sg.missing_info || []).length > 0, missingInfo: sg.missing_info || [],
+      hasQuestions: (sg.next_questions || []).length > 0, nextQuestions: sg.next_questions || [],
+      hasFollow: (sg.follow_ups || []).length > 0, followUps: sg.follow_ups || [],
+      caveat: sg.caveat || "",
+
+      // why
+      whyOpen, why, hasCases: (why.cases || []).length > 0,
+      whyBtnStyle, whyBtnLabel: whyOpen ? "▾ Why this guidance" : "▸ Why this guidance",
+
+      // metrics
+      curEmotion, curTopic,
+      traj: { has: trajHas, points: trajPoints }, trajDelta, trajDeltaStyle,
+
+      // composer
+      draft: s.draft, notes: s.notes,
+      patientTabStyle, doctorTabStyle, composerPlaceholder, advanceStyle, advanceHint,
+
+      // report modal
+      reportOpen: s.reportOpen, report,
+
+      // handlers
+      advance: this.advance, send: this.send, onDraft: this.onDraft, onComposerKey: this.onComposerKey,
+      onNotes: this.onNotes, setSpeakerPatient: this.setSpeakerPatient, setSpeakerDoctor: this.setSpeakerDoctor,
+      toggleWhy: this.toggleWhy, openReport: this.openReport, closeReport: this.closeReport, stop: this.stop,
+      scrollRef: this.scrollRef,
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/cockpit_component/support.js
+++ b/cockpit_component/support.js
@@ -1,0 +1,1513 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:rgba(0,0,0,.7);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:rgba(0,0,0,.5);background:rgba(0,0,0,.05);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      section, article, figure, table { break-inside: avoid; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+      const raw = t ? parseDcText(t) : null;
+      if (raw?.template) runtime.updateHtml(rootName, raw.template);
+    }).catch(() => {
+    });
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      return h(Root, entry.propOverrides || null);
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, isComponent, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (isComponent) {
+        if (key.includes("-")) key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, true, host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) props[k] = g(vals);
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const url = el.getAttribute("from") || el.getAttribute("src") || el.getAttribute("import") || "";
+    const kind = /\.(jsx|tsx)(\?|#|$)/i.test(url) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, true, host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const kids = hasContent ? walkChildren(el, host) : [];
+    const urlBindable = url.includes("{{");
+    if (url && !urlBindable) host.loadExternal(kind, url);
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "name" || k === "from" || k === "src" || k === "import") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const { propGetters, pseudoClasses } = collectProps(el, false, host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = { key, "data-dc-tpl": tplId };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...kids.map((b, j) => b(vals, ctx, j)));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h("div", { className: "sc-logic-error" }, renderErr),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.26.4/babel.min.js";
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = BABEL_URL;
+        s.crossOrigin = "anonymous";
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    function load(kind, url) {
+      if (cache.has(url)) return;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = kind === "jsx" ? ensureBabel() : Promise.resolve();
+      ready.then(() => fetch(url)).then((r) => {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.text();
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/helmet.ts
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile };
+  }
+
+  // src/pseudo.ts
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const sel = pseudo === "before" || pseudo === "after" ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(sel + "{" + css + "}", el.sheet.cssRules.length);
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url) => external.load(kind, url),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      fetch(url).then((res) => {
+        if (!res.ok) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/> failed:",
+            url,
+            "returned",
+            res.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res.text();
+      }).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/>:",
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          "[dc-runtime] sibling fetch for <" + name + "/> threw:",
+          url,
+          e
+        )
+      );
+    }
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/index.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      s.integrity = integrity;
+      s.crossOrigin = "anonymous";
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    return Promise.all([
+      loadScript(REACT_URL, REACT_SRI),
+      loadScript(REACT_DOM_URL, REACT_DOM_SRI)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const api = {
+      __dcUpdate: (name, kind, content, streaming) => {
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`<sc-comp>`,
+       *  `sc-camel-*` attrs); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import ui
 
 
 def _assistant_analyses(conversation):
@@ -6,86 +7,46 @@ def _assistant_analyses(conversation):
     return [m["analysis"] for m in (conversation or []) if m.get("analysis")]
 
 
-def render_dashboard(conversation, patient_profile):
-    """Render the live counselor dashboard from the conversation's analytics.
-
-    Reads only data already produced per message (sentiment, urgency/emotion,
-    topic, safety) — no model calls here.
-    """
-    st.subheader("Live session dashboard")
+def trajectory(conversation):
+    """Build the sentiment sparkline (points string + signed delta) from the
+    per-message sentiment scores. Mirrors the cockpit metric geometry."""
     analyses = _assistant_analyses(conversation)
-
-    if not analyses:
-        st.caption("Emotional and risk metrics appear here as the conversation progresses.")
-        _render_profile(patient_profile)
-        return
-
-    latest = analyses[-1]
-    flagged = [a.get("safety_protocol") for a in analyses if a.get("safety_protocol")]
-
-    # Current risk status
-    sp = latest.get("safety_protocol")
-    if sp:
-        label = f"Risk: {sp.get('action', 'URGENT')} — {sp.get('flag_type')}"
-        (st.error if sp.get("action") == "CRITICAL" else st.warning)(label)
-    elif flagged:
-        st.warning(f"Risk: {len(flagged)} flag(s) earlier this session")
+    scores = [a.get("sentiment_score") for a in analyses
+              if isinstance(a.get("sentiment_score"), (int, float))]
+    if len(scores) < 2:
+        return "", "—", "#8a93a8", False
+    n = len(scores)
+    pts = []
+    for i, v in enumerate(scores):
+        x = (i / (n - 1)) * 240
+        y = max(4.0, min(56.0, 30 - (v * 26)))
+        pts.append(f"{x:.1f},{y:.1f}")
+    delta = scores[-1] - scores[0]
+    if delta > 0.02:
+        txt, color = f"▲ +{delta:.2f}", "#2f8f6b"
+    elif delta < -0.02:
+        txt, color = f"▼ {delta:.2f}", "#b23a31"
     else:
-        st.success("Risk: none detected")
-
-    # Metric cards
-    c1, c2, c3 = st.columns(3)
-    score = latest.get("sentiment_score")
-    c1.metric("Sentiment", latest.get("sentiment") or "—",
-              f"{score:+.2f}" if isinstance(score, (int, float)) else None)
-    urgency = latest.get("urgency") or {}
-    emotion = urgency.get("label")
-    c2.metric("Emotion", emotion.title() if emotion else "—")
-    c3.metric("Topic", latest.get("topic") or "—")
-
-    bits = []
-    if isinstance(urgency.get("score"), (int, float)):
-        bits.append(f"emotion {urgency['score']:.0%}")
-    if isinstance(latest.get("topic_confidence"), (int, float)):
-        bits.append(f"topic {latest['topic_confidence']:.0%}")
-    if bits:
-        st.caption(" · ".join(bits) + " confidence")
-
-    # Emotional trajectory
-    scores = [a.get("sentiment_score") for a in analyses if isinstance(a.get("sentiment_score"), (int, float))]
-    if len(scores) >= 2:
-        st.caption("Emotional trajectory · sentiment per message")
-        st.line_chart(scores, height=160)
-
-    # Safety timeline
-    if flagged:
-        st.caption("Safety timeline")
-        for i, a in enumerate(analyses, start=1):
-            f = a.get("safety_protocol")
-            if f:
-                st.markdown(f"- Message {i}: **{f.get('action')}** — {f.get('flag_type')}")
-
-    # Topics detected this session
-    topics = []
-    for a in analyses:
-        topic = a.get("topic")
-        if topic and topic not in topics:
-            topics.append(topic)
-    if topics:
-        st.caption("Topics detected")
-        st.markdown(" ".join(f"`{t}`" for t in topics))
-
-    _render_profile(patient_profile)
+        txt, color = "→ flat", "#8a93a8"
+    return " ".join(pts), txt, color, True
 
 
-def _render_profile(patient_profile):
-    profile = patient_profile or {}
-    mh = profile.get("medical_history") or []
-    tg = profile.get("therapy_goals") or []
-    if not (mh or tg):
-        return
-    st.caption("Patient profile")
-    if mh:
-        st.markdown("**History:** " + ", ".join(mh))
-    if tg:
-        st.markdown("**Goals:** " + ", ".join(tg))
+def render_dashboard(conversation, patient_profile=None):
+    """Right-column session metrics: current emotion, topic, sentiment trajectory.
+
+    Reads only data already produced per message — no model calls here.
+    """
+    analyses = _assistant_analyses(conversation)
+    emotion, topic = "—", "—"
+    if analyses:
+        latest = analyses[-1]
+        urgency = latest.get("urgency") or {}
+        if urgency.get("label"):
+            emotion = str(urgency["label"]).title()
+        topic = latest.get("topic") or "—"
+
+    points, delta_text, delta_color, has = trajectory(conversation)
+    st.markdown(
+        ui.metrics_panel(emotion, topic, points, delta_text, delta_color, has),
+        unsafe_allow_html=True,
+    )

--- a/explain.py
+++ b/explain.py
@@ -53,43 +53,40 @@ def render_advice(advice_text):
 
 
 def render_why(analysis):
-    """Per-message 'Why this guidance' expander: the signals, retrieved cases,
-    and the exact context sent to the model."""
+    """'Why this guidance' grounding panel: the driving signals, retrieved
+    cases, and the exact context sent to the model — in the cockpit style."""
     import streamlit as st
+    import ui
     if not analysis:
         return
-    with st.expander("Why this guidance"):
-        st.markdown("**Signals that informed this**")
-        rows = []
-        topic, tconf = analysis.get("topic"), analysis.get("topic_confidence")
-        if topic:
-            note = " · weak hint" if isinstance(tconf, (int, float)) and tconf < 0.4 else ""
-            conf = f" · {tconf:.0%} confidence{note}" if isinstance(tconf, (int, float)) else ""
-            rows.append(f"- Topic: `{topic}`{conf}")
-        sentiment, sscore = analysis.get("sentiment"), analysis.get("sentiment_score")
-        if sentiment:
-            score = f" ({sscore:+.2f})" if isinstance(sscore, (int, float)) else ""
-            rows.append(f"- Sentiment: {sentiment}{score}")
-        urgency = analysis.get("urgency") or {}
-        if urgency.get("label"):
-            score = f" ({urgency['score']:.0%})" if isinstance(urgency.get("score"), (int, float)) else ""
-            rows.append(f"- Emotion: {urgency['label']}{score}")
-        sp = analysis.get("safety_protocol")
-        if sp:
-            rows.append(f"- Safety: **{sp.get('action')}** — {sp.get('flag_type')}")
-        st.markdown("\n".join(rows) if rows else "_No signals recorded._")
 
-        examples = analysis.get("historical_examples") or []
-        st.markdown(f"**Similar past cases retrieved ({len(examples)})**")
-        if examples:
-            for ex in examples[:3]:
-                q = (ex.get("questionText") or "")[:200]
-                a = (ex.get("answerText") or "")[:200]
-                st.markdown(f"- *Patient:* {q}\n\n  *Therapist:* {a}")
-        else:
-            st.caption("None retrieved (semantic search returned no matches).")
+    signals = []
+    topic, tconf = analysis.get("topic"), analysis.get("topic_confidence")
+    if topic:
+        conf = f" · {tconf:.0%}" if isinstance(tconf, (int, float)) else ""
+        signals.append(("Topic (BART zero-shot)", f"{topic}{conf}"))
+    sentiment, sscore = analysis.get("sentiment"), analysis.get("sentiment_score")
+    if sentiment:
+        score = f" · {sscore:+.2f}" if isinstance(sscore, (int, float)) else ""
+        signals.append(("Sentiment (RoBERTa)", f"{sentiment}{score}"))
+    urgency = analysis.get("urgency") or {}
+    if urgency.get("label"):
+        score = f" · {urgency['score']:.0%}" if isinstance(urgency.get("score"), (int, float)) else ""
+        signals.append(("Emotion (DistilRoBERTa)", f"{urgency['label']}{score}"))
+    sp = analysis.get("safety_protocol")
+    signals.append(("Crisis screen", f"{sp.get('flag_type')} · {sp.get('action')}" if sp else "clear"))
 
-        context = analysis.get("analysis_context")
-        if context:
-            st.markdown("**Context sent to the model**")
-            st.code(context)
+    cases = []
+    for ex in (analysis.get("historical_examples") or [])[:3]:
+        cases.append({
+            "id": ex.get("questionID") or ex.get("id") or "—",
+            "sim": "",
+            "q": (ex.get("questionText") or "")[:200],
+            "a": (ex.get("answerText") or "")[:200],
+        })
+
+    with st.expander("Why this guidance — grounding"):
+        st.markdown(
+            ui.why_panel(signals, cases, analysis.get("analysis_context") or "(no context assembled)"),
+            unsafe_allow_html=True,
+        )

--- a/patient_overview.py
+++ b/patient_overview.py
@@ -9,6 +9,24 @@ def _fmt_date(value):
         return str(value)[:10]
 
 
+def _days_ago(value):
+    """Best-effort '· Nd ago' suffix from a date/datetime/ISO string."""
+    from datetime import datetime, date
+    try:
+        if hasattr(value, "year") and not isinstance(value, datetime):
+            d = datetime(value.year, value.month, value.day)
+        elif isinstance(value, datetime):
+            d = value
+        else:
+            d = datetime.fromisoformat(str(value)[:19])
+        days = (datetime.now() - d).days
+        if days <= 0:
+            return "today"
+        return f"{days}d ago"
+    except Exception:
+        return ""
+
+
 def build_patient_summary(profile):
     """Compact text summary of the patient record for the LLM prompt."""
     profile = profile or {}
@@ -37,20 +55,21 @@ def build_history_summary(sessions, limit=5):
 
 
 def render_patient_overview(patient_id, profile=None, exclude_session_id=None):
-    """Top patient-context card + collapsible history timeline for the doctor.
+    """Left-column patient context: overview card + session-history timeline.
 
     Reads the profile (passed in to avoid a re-fetch) and the patient's prior
     session logs. ``exclude_session_id`` drops the in-progress session so the
     counts/timeline reflect *prior* context.
     """
     import streamlit as st
-    from patient_profile import get_patient_sessions
+    import ui
 
     profile = profile or {}
     medical_history = profile.get("medical_history") or []
     therapy_goals = profile.get("therapy_goals") or []
 
     try:
+        from patient_profile import get_patient_sessions
         sessions = get_patient_sessions(patient_id)
     except Exception:
         sessions = []
@@ -58,40 +77,26 @@ def render_patient_overview(patient_id, profile=None, exclude_session_id=None):
         sessions = [s for s in sessions if s.get("session_id") != exclude_session_id]
 
     last = sessions[0] if sessions else None
-
-    cols = st.columns([2, 1, 1])
-    cols[0].markdown(f"**Patient** `{patient_id}`")
-    cols[1].metric("Past sessions", len(sessions))
-    cols[2].metric("Last seen", _fmt_date(last.get("created_at")) if last else "—")
-
-    if medical_history:
-        st.markdown("**Clinical history:** " + " · ".join(f"`{x}`" for x in medical_history))
-    if therapy_goals:
-        st.markdown("**Therapy goals:** " + ", ".join(therapy_goals))
-
+    subtitle = "returning patient" if sessions else "new patient"
     if last:
-        bits = []
-        topics = last.get("detected_topics") or []
-        flags = last.get("risk_flags") or []
-        score = last.get("sentiment_score")
-        if topics:
-            bits.append("topics: " + ", ".join(topics))
-        if flags:
-            bits.append("risk flags: " + ", ".join(flags))
-        if isinstance(score, (int, float)):
-            bits.append(f"sentiment {score:+.2f}")
-        if bits:
-            st.caption("Most recent session — " + " · ".join(bits))
-
-    if sessions:
-        with st.expander(f"Session history ({len(sessions)})"):
-            for s in sessions[:20]:
-                date = _fmt_date(s.get("created_at"))
-                topics = ", ".join(s.get("detected_topics") or []) or "—"
-                flags = ", ".join(s.get("risk_flags") or [])
-                flag_txt = f" · risk: {flags}" if flags else ""
-                score = s.get("sentiment_score")
-                score_txt = f" · sentiment {score:+.2f}" if isinstance(score, (int, float)) else ""
-                st.markdown(f"- **{date}** — {topics}{flag_txt}{score_txt}")
+        ago = _days_ago(last.get("created_at"))
+        last_seen = _fmt_date(last.get("created_at")) + (f" · {ago}" if ago else "")
     else:
-        st.caption("No prior sessions on record for this patient.")
+        last_seen = "first session"
+
+    st.markdown(
+        ui.patient_overview_card(patient_id, subtitle, len(sessions),
+                                 medical_history, therapy_goals, last_seen),
+        unsafe_allow_html=True,
+    )
+
+    items = []
+    for s in sessions[:8]:
+        flags = s.get("risk_flags") or []
+        items.append({
+            "date": _fmt_date(s.get("created_at")),
+            "topics": s.get("detected_topics") or [],
+            "score": s.get("sentiment_score"),
+            "flag": flags[0] if flags else None,
+        })
+    st.markdown(ui.history_timeline(items), unsafe_allow_html=True)

--- a/session_assistant.py
+++ b/session_assistant.py
@@ -100,78 +100,36 @@ def generate_session_suggestions(transcript, patient_summary, history_summary,
         return out
 
 
-_CONF_LABEL = {
-    "high": "high confidence",
-    "medium": "medium confidence",
-    "low": "low confidence — treat as a hint",
-}
-
-
 def render_suggestions(data, analysis):
-    """Render the assistant panel: deterministic safety first, then LLM aids."""
+    """Render the cockpit decision-support panel + the grounding ('why') toggle.
+
+    The deterministic crisis banner is rendered separately (above the
+    transcript) by the app; here we show the LLM aids and degraded-state notes.
+    """
     import streamlit as st
+    import ui
     from explain import render_why
 
     data = data or {}
     analysis = analysis or {}
 
-    # 1. Deterministic safety — never depends on the LLM.
-    sp = analysis.get("safety_protocol")
-    if sp:
-        st.error(
-            f"Safety — {sp.get('action')}: {sp.get('flag_type')}. {sp.get('response', '')}"
-        )
+    st.markdown(
+        ui.decision_support(
+            state=data.get("emotional_state"),
+            confidence=data.get("state_confidence"),
+            red_flags=data.get("red_flags") or [],
+            missing=data.get("missing_info") or [],
+            questions=data.get("next_questions") or [],
+            follow_ups=data.get("follow_ups") or [],
+            caveat=data.get("caveat"),
+            error=bool(data.get("_error")),
+            degraded=analysis.get("errors") or [],
+        ),
+        unsafe_allow_html=True,
+    )
 
-    # Surface a degraded run instead of silently showing an empty panel.
-    if data.get("_error"):
-        st.warning(
-            "The assistant could not generate suggestions for this turn (model "
-            "error). The deterministic safety check above still applies."
-        )
-    degraded = analysis.get("errors") or []
-    if degraded:
-        st.caption("⚠️ Limited analysis — unavailable: " + ", ".join(degraded))
-
-    red = data.get("red_flags") or []
-    if red:
-        st.markdown("**Red flags / concerns**")
-        for item in red:
-            st.markdown(f"- {item}")
-
-    missing = data.get("missing_info") or []
-    if missing:
-        st.markdown("**Missing info to clarify**")
-        for item in missing:
-            st.markdown(f"- {item}")
-
-    state = data.get("emotional_state")
-    if state:
-        conf = _CONF_LABEL.get((data.get("state_confidence") or "low"), _CONF_LABEL["low"])
-        st.markdown(f"**Likely state** — {state}")
-        st.caption(conf)
-
-    questions = data.get("next_questions") or []
-    if questions:
-        st.markdown("**Next questions to consider**")
-        for q in questions:
-            st.markdown(f"- {q}")
-
-    follow_ups = data.get("follow_ups") or []
-    if follow_ups:
-        st.markdown("**Follow-up points**")
-        for item in follow_ups:
-            st.markdown(f"- {item}")
-
-    if data.get("caveat"):
-        st.caption(f"Note: {data['caveat']}")
     if data.get("_raw"):
         with st.expander("Raw assistant output (could not parse as JSON)"):
             st.code(data["_raw"])
 
-    if not any(data.get(k) for k in ("red_flags", "missing_info", "emotional_state",
-                                     "next_questions", "follow_ups")) and not sp \
-            and not data.get("_error"):
-        st.caption("No high-value suggestions for this turn.")
-
-    st.caption("Decision support — not a diagnosis. Clinical judgment required.")
     render_why(analysis)

--- a/ui.py
+++ b/ui.py
@@ -1,0 +1,458 @@
+"""Cockpit UI theme + presentational HTML builders.
+
+Pure string builders (no Streamlit import) so the markup can be previewed
+standalone. The Streamlit render_* functions call these and pass the result to
+st.markdown(..., unsafe_allow_html=True). Every builder returns a single-line
+HTML string (no embedded newlines) so Streamlit's markdown pass never treats
+indented lines as a code block.
+"""
+from __future__ import annotations
+import html as _html
+
+# ---- design tokens (ported from the Live Session Cockpit mockup) ----
+ACCENT = "#3563d4"
+ACCENT_SOFT = "rgba(53,99,212,.1)"
+BG = "#eef1f6"
+INK = "#1a2235"
+MUTED = "#8a93a8"
+BORDER = "#dde3ee"
+CRISIS = "#c2362f"
+GREEN = "#2f8f6b"
+MONO = "'IBM Plex Mono',ui-monospace,monospace"
+
+
+def esc(value) -> str:
+    """HTML-escape arbitrary (possibly user-entered) content."""
+    return _html.escape("" if value is None else str(value))
+
+
+def _pre(value) -> str:
+    """Escape and keep the string single-line (newlines -> entities)."""
+    return esc(value).replace("\n", "&#10;")
+
+
+# ---------------------------------------------------------------- global CSS
+def css() -> str:
+    """The global <style> block: fonts, chrome hiding, theming, widgets."""
+    return """
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap');
+
+:root { --accent:#3563d4; --ink:#1a2235; --muted:#8a93a8; --border:#dde3ee; }
+
+.stApp, [data-testid="stAppViewContainer"] { background:#eef1f6; }
+[data-testid="stHeader"] { background:transparent; }
+#MainMenu, footer, [data-testid="stToolbar"] { visibility:hidden; }
+html, body, [class*="st-"], .stMarkdown, button, input, textarea {
+  font-family:'Public Sans',system-ui,-apple-system,sans-serif; color:#1a2235;
+}
+.block-container { padding:1.1rem 1.4rem 7rem; max-width:1560px; }
+[data-testid="stVerticalBlock"] { gap:.7rem; }
+[data-testid="stHorizontalBlock"] { gap:.85rem; }
+hr { margin:.5rem 0; border-color:#dde3ee; }
+
+/* section label */
+.lsa-h { display:flex; align-items:center; gap:8px; margin-bottom:13px; }
+.lsa-h .bar { width:3px; height:13px; border-radius:2px; background:var(--accent); }
+.lsa-h .t { font:600 10.5px/1 'IBM Plex Mono',monospace; letter-spacing:.07em; color:#8a93a8; }
+.lsa-card { background:#fff; border:1px solid #dde3ee; border-radius:11px; padding:16px; }
+
+/* buttons */
+.stButton>button, .stFormSubmitButton>button, [data-testid="stBaseButton-primary"],
+[data-testid="stBaseButton-secondary"] {
+  border-radius:8px; font-weight:600; font-family:inherit; font-size:13.5px;
+  transition:filter .15s ease, background .15s ease; box-shadow:none;
+}
+.stButton>button[kind="primary"], .stFormSubmitButton>button[kind="primary"],
+.stFormSubmitButton>button[kind="primaryFormSubmit"], [data-testid="stBaseButton-primary"],
+[data-testid="stBaseButton-primaryFormSubmit"] {
+  background:#3563d4 !important; color:#fff !important; border:none !important;
+}
+.stButton>button[kind="primary"]:hover, .stFormSubmitButton>button:hover { filter:brightness(1.06); }
+.stButton>button[kind="secondary"], [data-testid="stBaseButton-secondary"] {
+  background:#fff !important; color:#3a4458 !important; border:1px solid #dde3ee !important;
+}
+.stButton>button[kind="secondary"]:hover { border-color:#3563d4 !important; color:#28304a !important; }
+
+/* inputs */
+[data-testid="stTextInput"] input, [data-testid="stTextArea"] textarea,
+[data-baseweb="input"] input, [data-baseweb="textarea"] textarea {
+  border:1px solid #dde3ee !important; border-radius:9px !important; background:#fbfcfe !important;
+  color:#1a2235 !important; font-family:inherit; font-size:13.5px;
+}
+[data-testid="stTextInput"] input:focus, [data-testid="stTextArea"] textarea:focus {
+  border-color:#3563d4 !important; box-shadow:0 0 0 2px rgba(53,99,212,.15) !important;
+}
+[data-baseweb="input"], [data-baseweb="textarea"], [data-baseweb="base-input"] {
+  background:#fbfcfe !important; border-radius:9px !important;
+}
+[data-testid="stWidgetLabel"] p, [data-testid="stWidgetLabel"] label {
+  font:600 10.5px/1 'IBM Plex Mono',monospace !important; letter-spacing:.05em; color:#8a93a8 !important;
+  text-transform:uppercase;
+}
+
+/* radio as a segmented toggle */
+[data-testid="stRadio"] [role="radiogroup"] {
+  flex-direction:row; gap:4px; background:#eef1f6; padding:3px; border-radius:8px;
+  width:max-content;
+}
+[data-testid="stRadio"] [role="radiogroup"] label {
+  margin:0; padding:6px 14px; border-radius:6px; cursor:pointer;
+  font:600 12px/1 'Public Sans',sans-serif; color:#7a849c;
+}
+[data-testid="stRadio"] [role="radiogroup"] label:has(input:checked) { background:#3563d4; color:#fff; }
+[data-testid="stRadio"] [role="radiogroup"] label > div:first-child { display:none; }
+
+/* chat input pinned at bottom */
+[data-testid="stChatInput"] { border-radius:9px; }
+[data-testid="stBottomBlockContainer"] { background:#eef1f6; }
+
+/* expander = light card */
+[data-testid="stExpander"] { border:1px solid #dde3ee; border-radius:11px; background:#fff; }
+[data-testid="stExpander"] summary { font:600 10.5px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; color:#8a93a8; }
+
+/* alerts */
+[data-testid="stAlert"] { border-radius:9px; }
+
+/* scrollbars */
+.lsa-scroll::-webkit-scrollbar { width:9px; }
+.lsa-scroll::-webkit-scrollbar-thumb { background:#d3dae8; border-radius:6px; border:2px solid #fff; }
+.lsa-scroll::-webkit-scrollbar-track { background:transparent; }
+
+@keyframes fadeUp { from { opacity:0; transform:translateY(6px); } to { opacity:1; transform:none; } }
+@keyframes spin { to { transform:rotate(360deg); } }
+@keyframes softpulse { 0%,100% { opacity:1; } 50% { opacity:.45; } }
+@keyframes crisisPulse { 0%,100% { box-shadow:0 0 0 0 rgba(194,54,47,.28); } 50% { box-shadow:0 0 0 5px rgba(194,54,47,0); } }
+</style>
+"""
+
+
+def _h(label: str) -> str:
+    return (f'<div class="lsa-h"><span class="bar"></span>'
+            f'<span class="t">{esc(label)}</span></div>')
+
+
+# --------------------------------------------------------------- launch hero
+def launch_hero() -> str:
+    return (
+        '<div style="display:flex;flex-direction:column;align-items:center;text-align:center;margin:8px 0 22px;">'
+        '<div style="width:46px;height:46px;border-radius:13px;background:#3563d4;display:flex;align-items:center;justify-content:center;">'
+        '<div style="width:19px;height:19px;border:2.6px solid #fff;border-radius:50%;border-right-color:transparent;"></div></div>'
+        '<h1 style="font-weight:700;font-size:27px;letter-spacing:-.025em;margin:16px 0 0;">Live Session Assistant</h1>'
+        f'<div style="font:600 11px/1 {MONO};letter-spacing:.16em;color:#8a93a8;margin-top:9px;">CLINICAL DECISION SUPPORT</div>'
+        '<p style="font-size:14px;line-height:1.6;color:#5e6a82;max-width:460px;margin:14px 0 0;">A real-time co-pilot for '
+        'mental-health sessions. Open a patient to load their history and session context, then get grounded, in-the-moment '
+        'decision support.</p>'
+        '<div style="display:inline-flex;align-items:center;gap:8px;margin-top:16px;padding:7px 13px;border:1px solid #f0d9d6;background:#fdf4f3;border-radius:20px;">'
+        '<span style="width:7px;height:7px;border-radius:50%;background:#c2362f;"></span>'
+        '<span style="font-size:12px;font-weight:600;color:#9c453f;">Decision support — not a diagnosis</span></div></div>'
+    )
+
+
+def launch_footer() -> str:
+    return (
+        '<div style="text-align:center;margin-top:18px;font-size:11.5px;color:#9aa3b6;line-height:1.55;">'
+        f'Access is gated by a shared password when <span style="font-family:{MONO};">APP_PASSWORD</span> is configured. '
+        'Use de-identified patient data only.</div>'
+    )
+
+
+# --------------------------------------------------------------- header bar
+def header_bar(patient_id: str, clock: str, turns: int) -> str:
+    return (
+        '<div style="display:flex;align-items:center;gap:16px;background:#fff;border:1px solid #dde3ee;'
+        'border-radius:11px;padding:11px 18px;margin-bottom:4px;">'
+        '<div style="width:30px;height:30px;border-radius:8px;background:#3563d4;display:flex;align-items:center;justify-content:center;flex:none;">'
+        '<div style="width:13px;height:13px;border:2.2px solid #fff;border-radius:50%;border-right-color:transparent;"></div></div>'
+        '<div style="display:flex;flex-direction:column;line-height:1.1;">'
+        '<span style="font-weight:700;font-size:15px;letter-spacing:-.01em;">Live Session Assistant</span>'
+        f'<span style="font:500 10px/1 {MONO};color:#8a93a8;letter-spacing:.04em;margin-top:3px;">CLINICAL DECISION SUPPORT</span></div>'
+        '<div style="display:flex;align-items:center;gap:8px;padding:5px 11px;background:#f4f6fa;border:1px solid #e3e8f2;border-radius:8px;">'
+        f'<span style="font:500 11px/1 {MONO};color:#8a93a8;">PATIENT</span>'
+        f'<span style="font:600 13px/1 {MONO};color:#1a2235;">{esc(patient_id)}</span>'
+        '<span style="width:6px;height:6px;border-radius:50%;background:#2f8f6b;box-shadow:0 0 0 3px rgba(47,143,107,.16);"></span>'
+        '<span style="font-size:11.5px;font-weight:600;color:#2f8f6b;">Session live</span></div>'
+        '<div style="margin-left:auto;display:flex;align-items:center;gap:16px;">'
+        f'<div style="display:flex;align-items:center;gap:7px;"><span style="font:500 10px/1 {MONO};color:#9aa3b6;">ELAPSED</span>'
+        f'<span style="font:600 14px/1 {MONO};color:#1a2235;">{esc(clock)}</span></div>'
+        f'<div style="display:flex;align-items:center;gap:7px;"><span style="font:500 10px/1 {MONO};color:#9aa3b6;">TURNS</span>'
+        f'<span style="font:600 14px/1 {MONO};color:#1a2235;">{turns}</span></div>'
+        '<div style="display:flex;align-items:center;gap:6px;padding:6px 11px;border:1px solid #f0d9d6;background:#fdf4f3;border-radius:8px;">'
+        '<span style="width:7px;height:7px;border-radius:50%;background:#c2362f;flex:none;"></span>'
+        '<span style="font-size:11.5px;font-weight:600;color:#9c453f;">Not a diagnosis</span></div></div></div>'
+    )
+
+
+# --------------------------------------------------------- patient overview
+def patient_overview_card(patient_id, subtitle, sessions, history, goals, last_seen) -> str:
+    hist = "".join(
+        f'<span style="font:500 11.5px/1 {MONO};background:#f0f3f9;color:#4a5670;padding:5px 8px;border-radius:6px;">{esc(h)}</span>'
+        for h in (history or [])
+    ) or '<span style="font-size:12px;color:#aab2c4;">No history recorded</span>'
+    goal_items = "".join(
+        f'<li style="display:flex;gap:8px;font-size:13px;color:#3a4458;"><span style="color:{ACCENT};">›</span>{esc(g)}</li>'
+        for g in (goals or [])
+    ) or '<li style="font-size:12px;color:#aab2c4;list-style:none;">No goals recorded</li>'
+    return (
+        '<div class="lsa-card">' + _h("PATIENT OVERVIEW") +
+        '<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;">'
+        f'<div><div style="font:600 19px/1 {MONO};">{esc(patient_id)}</div>'
+        f'<div style="font-size:12.5px;color:#647089;margin-top:4px;">{esc(subtitle)}</div></div>'
+        '<div style="text-align:center;background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:7px 12px;">'
+        f'<div style="font:600 17px/1 {MONO};">{sessions}</div>'
+        '<div style="font-size:9.5px;color:#8a93a8;margin-top:3px;letter-spacing:.02em;">SESSIONS</div></div></div>'
+        '<div style="margin-top:15px;"><div style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;margin-bottom:7px;">CLINICAL HISTORY</div>'
+        f'<div style="display:flex;flex-wrap:wrap;gap:6px;">{hist}</div></div>'
+        '<div style="margin-top:14px;"><div style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;margin-bottom:7px;">THERAPY GOALS</div>'
+        f'<ul style="margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:6px;">{goal_items}</ul></div>'
+        '<div style="margin-top:15px;padding-top:13px;border-top:1px dashed #e3e8f2;display:flex;justify-content:space-between;font-size:12px;">'
+        f'<span style="color:#8a93a8;">Last seen</span><span style="font-weight:600;color:#3a4458;font-family:{MONO};">{esc(last_seen)}</span></div></div>'
+    )
+
+
+def history_timeline(items) -> str:
+    if not items:
+        body = '<div style="font-size:12.5px;color:#aab2c4;">No prior sessions on record.</div>'
+    else:
+        rows = []
+        n = len(items)
+        for i, t in enumerate(items):
+            dot = CRISIS if t.get("flag") else (ACCENT if i == 0 else "#c2cad8")
+            line = ("display:none;" if i == n - 1
+                    else "flex:1;width:1.5px;background:#e6eaf2;margin:3px 0;")
+            sc = t.get("score")
+            sc_color = "#647089"
+            if isinstance(sc, (int, float)):
+                sc_color = "#b23a31" if sc < -0.6 else "#b5862f" if sc < -0.3 else "#647089"
+            sc_txt = (f'{sc:+.2f}' if isinstance(sc, (int, float)) else "—")
+            topics = "".join(
+                f'<span style="font:500 10.5px/1 {MONO};background:#eef1f6;color:#647089;padding:3px 6px;border-radius:5px;">{esc(tp)}</span>'
+                for tp in (t.get("topics") or [])
+            )
+            flag = ""
+            if t.get("flag"):
+                flag = ('<div style="display:inline-flex;align-items:center;gap:5px;margin-top:7px;padding:3px 7px;background:#fdeceb;border:1px solid #f3c9c5;border-radius:5px;">'
+                        '<span style="width:5px;height:5px;border-radius:50%;background:#c2362f;"></span>'
+                        f'<span style="font:600 10px/1 {MONO};color:#a8423b;">risk: {esc(t.get("flag"))}</span></div>')
+            rows.append(
+                '<div style="display:grid;grid-template-columns:14px 1fr;gap:11px;">'
+                '<div style="display:flex;flex-direction:column;align-items:center;">'
+                f'<span style="width:10px;height:10px;border-radius:50%;flex:none;margin-top:3px;background:{dot};"></span>'
+                f'<span style="{line}"></span></div>'
+                '<div style="padding-bottom:14px;"><div style="display:flex;align-items:center;justify-content:space-between;gap:6px;">'
+                f'<span style="font:600 12px/1 {MONO};color:#3a4458;">{esc(t.get("date"))}</span>'
+                f'<span style="font:600 11px/1 {MONO};color:{sc_color};">{sc_txt}</span></div>'
+                f'<div style="display:flex;flex-wrap:wrap;gap:5px;margin-top:7px;">{topics}</div>{flag}</div></div>'
+            )
+        body = "".join(rows)
+    return '<div class="lsa-card">' + _h("SESSION HISTORY") + body + '</div>'
+
+
+# ------------------------------------------------------------- crisis banner
+def crisis_banner(action, flag_type, response) -> str:
+    return (
+        '<div style="background:#fbeceb;border:1.5px solid #e9b8b3;border-radius:11px;padding:14px 16px;animation:crisisPulse 2.2s ease-in-out infinite;margin-bottom:4px;">'
+        '<div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">'
+        '<div style="width:26px;height:26px;border-radius:7px;background:#c2362f;color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:15px;flex:none;">!</div>'
+        f'<span style="font-weight:700;font-size:14px;color:#9c2f29;">CRISIS PROTOCOL — {esc(action)}</span>'
+        f'<span style="font:600 11px/1 {MONO};background:#f3d4d1;color:#9c2f29;padding:4px 8px;border-radius:5px;">{esc(flag_type)}</span>'
+        f'<span style="margin-left:auto;font:500 10.5px/1 {MONO};color:#b07a76;">DETERMINISTIC · RULE-BASED · NOT LLM</span></div>'
+        f'<p style="margin:10px 0 0;font-size:13px;line-height:1.55;color:#7a3a35;">{esc(response)}</p></div>'
+    )
+
+
+# ------------------------------------------------------------- transcript
+def transcript(messages, turns, height=420) -> str:
+    bubbles = []
+    for m in messages:
+        is_p = m.get("speaker") == "patient"
+        is_crisis = bool(m.get("crisis"))
+        base = "font-size:13.5px;line-height:1.55;padding:11px 13px;border-radius:10px;max-width:88%;border-top-left-radius:3px;"
+        if not is_p:
+            bub = base + "background:#f4f6fa;border:1px solid #e6eaf2;color:#2a3450;"
+            lab = f"font:600 10px/1 {MONO};letter-spacing:.05em;color:#8a93a8;text-transform:uppercase;"
+        elif is_crisis:
+            bub = base + "background:#fbeceb;border:1px solid #e9b8b3;color:#7a3a35;"
+            lab = f"font:600 10px/1 {MONO};letter-spacing:.05em;color:#c2362f;text-transform:uppercase;"
+        else:
+            bub = base + "background:#eef3fd;border:1px solid #d7e2fa;color:#26365e;"
+            lab = f"font:600 10px/1 {MONO};letter-spacing:.05em;color:{ACCENT};text-transform:uppercase;"
+        chips = "".join(
+            f'<span style="font:500 10.5px/1 {MONO};padding:4px 7px;border-radius:5px;background:{bg};color:{col};letter-spacing:.02em;">{esc(txt)}</span>'
+            for (txt, bg, col) in (m.get("chips") or [])
+        )
+        chips_html = (f'<div style="display:flex;flex-wrap:wrap;gap:6px;">{chips}</div>' if chips else "")
+        pending = ('<div style="display:flex;align-items:center;gap:7px;animation:softpulse 1.1s ease-in-out infinite;">'
+                   '<span style="width:6px;height:6px;border-radius:50%;background:#aab2c4;"></span>'
+                   f'<span style="font:500 11px/1 {MONO};color:#aab2c4;">analyzing turn…</span></div>') if m.get("pending") else ""
+        who = "Patient" if is_p else "Doctor"
+        bubbles.append(
+            '<div style="display:flex;flex-direction:column;gap:7px;animation:fadeUp .3s ease;">'
+            f'<div style="display:flex;align-items:center;gap:8px;"><span style="{lab}">{who}</span>'
+            f'<span style="font:500 10px/1 {MONO};color:#b4bccc;">{esc(m.get("time",""))}</span></div>'
+            f'<div style="{bub}">{esc(m.get("text"))}</div>{chips_html}{pending}</div>'
+        )
+    inner = "".join(bubbles) or '<div style="font-size:13px;color:#aab2c4;text-align:center;margin-top:30px;">No turns logged yet. Use the composer below to begin.</div>'
+    return (
+        '<div class="lsa-card" style="padding:0;">'
+        '<div style="display:flex;align-items:center;gap:8px;padding:14px 18px;border-bottom:1px solid #eef1f6;">'
+        '<span style="width:3px;height:13px;border-radius:2px;background:#3563d4;"></span>'
+        f'<span style="font:600 10.5px/1 {MONO};letter-spacing:.07em;color:#8a93a8;">LIVE TRANSCRIPT</span>'
+        '<span style="font-size:11.5px;color:#aab2c4;">two-channel · doctor &amp; patient</span>'
+        f'<span style="margin-left:auto;font:500 11px/1 {MONO};color:#aab2c4;">{turns} turns</span></div>'
+        f'<div class="lsa-scroll" style="max-height:{height}px;overflow-y:auto;padding:18px;display:flex;flex-direction:column;gap:16px;">{inner}</div></div>'
+    )
+
+
+# ----------------------------------------------------------- analysis pipeline
+def pipeline_panel(stages, running, status_label) -> str:
+    smap = {
+        "pending": ("background:#26314c;color:#5d6b8a;border:1px solid #2c3852;", "color:#6b7793;", ""),
+        "done": ("background:#2f8f6b;color:#fff;border:1px solid #2f8f6b;", "color:#cdd6e8;", "✓"),
+        "alert": ("background:#c2362f;color:#fff;border:1px solid #c2362f;", "color:#f0c4c0;font-weight:600;", "!"),
+        "running": ("background:#6f8fdc;color:#fff;border:1px solid #6f8fdc;", "color:#e6ecf8;font-weight:600;", "•"),
+    }
+    rows = []
+    for st_ in stages:
+        dot, lab, icon = smap.get(st_.get("status"), smap["pending"])
+        rows.append(
+            '<div style="display:flex;align-items:center;gap:10px;padding:5px 0;">'
+            f'<span style="width:18px;height:18px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;font:700 10px/1 {MONO};{dot}">{icon}</span>'
+            f'<span style="font-size:12.5px;{lab}">{esc(st_.get("label"))}</span>'
+            f'<span style="font:500 10px/1 {MONO};color:#5c6885;margin-left:auto;">{esc(st_.get("sub"))}</span></div>'
+        )
+    badge = ("background:#2a3a63;color:#9fb6f0;" if running else "background:#1f4a3a;color:#7fd6b0;")
+    return (
+        '<div style="background:#172033;border:1px solid #172033;border-radius:11px;padding:15px 16px;color:#cdd6e8;">'
+        '<div style="display:flex;align-items:center;gap:8px;margin-bottom:13px;">'
+        '<span style="width:3px;height:13px;border-radius:2px;background:#6f8fdc;"></span>'
+        f'<span style="font:600 10.5px/1 {MONO};letter-spacing:.07em;color:#8b97b4;">ANALYSIS PIPELINE</span>'
+        f'<span style="margin-left:auto;font:600 9.5px/1 {MONO};letter-spacing:.06em;padding:3px 7px;border-radius:5px;{badge}">{esc(status_label)}</span></div>'
+        f'<div style="display:flex;flex-direction:column;gap:3px;">{"".join(rows)}</div></div>'
+    )
+
+
+# ----------------------------------------------------------- decision support
+_CONF = {
+    "high": ("#e8f5ef", "#2f8f6b", "high confidence"),
+    "medium": ("#fbf6e9", "#b5862f", "medium confidence"),
+    "low": ("#eef1f6", "#8a93a8", "low — treat as a hint"),
+}
+
+
+def _list_block(items, *, bg, border, color, marker, marker_color):
+    rows = "".join(
+        f'<div style="display:flex;gap:8px;background:{bg};border:1px solid {border};border-radius:8px;padding:9px 11px;font-size:12.5px;line-height:1.45;color:{color};">'
+        f'<span style="color:{marker_color};font-weight:700;flex:none;">{marker}</span>{esc(it)}</div>'
+        for it in items
+    )
+    return f'<div style="display:flex;flex-direction:column;gap:7px;">{rows}</div>'
+
+
+def decision_support(state, confidence, red_flags, missing, questions,
+                     follow_ups, caveat, error=False, degraded=None) -> str:
+    parts = ['<div class="lsa-card">' + _h("DECISION SUPPORT")]
+
+    if error:
+        parts.append('<div style="background:#fdf4f3;border:1px solid #f0d9d6;border-radius:9px;padding:10px 12px;font-size:12.5px;color:#9c453f;margin-bottom:12px;">'
+                     'The assistant could not generate suggestions for this turn (model error). The deterministic safety check still applies.</div>')
+    if degraded:
+        parts.append(f'<div style="font:500 11px/1.4 {MONO};color:#b5862f;margin-bottom:11px;">⚠ Limited analysis — unavailable: {esc(", ".join(degraded))}</div>')
+
+    if state:
+        bg, col, lab = _CONF.get((confidence or "low"), _CONF["low"])
+        parts.append(
+            '<div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:9px;padding:12px;margin-bottom:13px;">'
+            '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px;">'
+            '<span style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;">LIKELY EMOTIONAL STATE</span>'
+            f'<span style="font:600 9.5px/1 {MONO};letter-spacing:.03em;padding:4px 7px;border-radius:5px;background:{bg};color:{col};">{lab}</span></div>'
+            f'<div style="font-size:14px;font-weight:600;color:#28304a;line-height:1.4;">{esc(state)}</div></div>'
+        )
+    if red_flags:
+        parts.append('<div style="margin-bottom:14px;"><div style="display:flex;align-items:center;gap:7px;margin-bottom:8px;">'
+                     '<span style="width:6px;height:6px;border-radius:2px;background:#c2362f;"></span>'
+                     '<span style="font-size:11px;font-weight:700;color:#a8423b;letter-spacing:.02em;">RED FLAGS / CONCERNS</span></div>'
+                     + _list_block(red_flags, bg="#fdeceb", border="#f3c9c5", color="#8a3833", marker="›", marker_color="#c2362f") + '</div>')
+    if missing:
+        parts.append('<div style="margin-bottom:14px;"><div style="font-size:11px;font-weight:700;color:#9a7a2a;letter-spacing:.02em;margin-bottom:8px;">MISSING INFO TO CLARIFY</div>'
+                     + _list_block(missing, bg="#fbf6e9", border="#efe1c0", color="#7a6420", marker="?", marker_color="#b5862f") + '</div>')
+    if questions:
+        parts.append('<div style="margin-bottom:14px;"><div style="font-size:11px;font-weight:700;color:#3052b8;letter-spacing:.02em;margin-bottom:8px;">NEXT QUESTIONS TO CONSIDER</div>'
+                     + _list_block(questions, bg="#eef3fd", border="#d7e2fa", color="#2f3e63", marker="→", marker_color=ACCENT) + '</div>')
+    if follow_ups:
+        items = "".join(
+            f'<div style="display:flex;gap:8px;font-size:12.5px;line-height:1.45;color:#4a5670;"><span style="color:#aab2c4;">•</span>{esc(f)}</div>'
+            for f in follow_ups
+        )
+        parts.append('<div style="margin-bottom:6px;"><div style="font-size:11px;font-weight:700;color:#647089;letter-spacing:.02em;margin-bottom:8px;">FOLLOW-UP POINTS</div>'
+                     f'<div style="display:flex;flex-direction:column;gap:6px;">{items}</div></div>')
+    if caveat:
+        parts.append(f'<div style="margin-top:10px;font-size:11.5px;font-style:italic;color:#9aa3b6;line-height:1.45;">Note: {esc(caveat)}</div>')
+
+    if not any([state, red_flags, missing, questions, follow_ups]) and not error:
+        parts.append('<div style="font-size:12.5px;color:#9aa3b6;">No high-value suggestions for this turn.</div>')
+
+    parts.append('<div style="margin-top:14px;padding-top:12px;border-top:1px dashed #e3e8f2;font-size:11px;color:#9aa3b6;line-height:1.45;">'
+                 'Every item is grounded in the patient record, the live transcript, and retrieved cases. The assistant suggests — it never decides. Clinical judgment required.</div>')
+    parts.append('</div>')
+    return "".join(parts)
+
+
+def why_panel(signals, cases, context) -> str:
+    sig = "".join(
+        '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;font-size:12px;">'
+        f'<span style="color:#647089;">{esc(k)}</span>'
+        f'<span style="font:600 11.5px/1 {MONO};color:#3a4458;">{esc(v)}</span></div>'
+        for (k, v) in (signals or [])
+    )
+    cases_html = ""
+    if cases:
+        def _case(c):
+            sim = c.get("sim")
+            badge = (f'<span style="font:600 10px/1 {MONO};color:#2f8f6b;">{esc(sim)} match</span>'
+                     if sim else '<span style="font:600 9.5px/1 ' + MONO + ';color:#aab2c4;">retrieved</span>')
+            return (
+                '<div style="background:#fff;border:1px solid #e6eaf2;border-radius:7px;padding:9px 10px;">'
+                '<div style="display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:5px;">'
+                f'<span style="font:600 9.5px/1 {MONO};color:#aab2c4;letter-spacing:.04em;">CORPUS · {esc(c.get("id"))}</span>{badge}</div>'
+                f'<div style="font-size:11.5px;color:#3a4458;line-height:1.4;margin-bottom:4px;">“{esc(c.get("q"))}”</div>'
+                f'<div style="font-size:11px;color:#8a93a8;line-height:1.4;">{esc(c.get("a"))}</div></div>'
+            )
+        cards = "".join(_case(c) for c in cases)
+        cases_html = ('<div style="font-size:10px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin:0 0 9px;">RETRIEVED SIMILAR CASES (RAG)</div>'
+                      f'<div style="display:flex;flex-direction:column;gap:8px;margin-bottom:13px;">{cards}</div>')
+    return (
+        '<div style="background:#f7f9fc;border:1px solid #e6eaf2;border-radius:9px;padding:13px;">'
+        '<div style="font-size:10px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:9px;">DRIVING SIGNALS</div>'
+        f'<div style="display:flex;flex-direction:column;gap:6px;margin-bottom:13px;">{sig}</div>{cases_html}'
+        '<div style="font-size:10px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:7px;">CONTEXT SENT TO MODEL</div>'
+        f'<pre style="margin:0;background:#172033;color:#aeb9d4;border-radius:7px;padding:10px;font:500 10.5px/1.5 {MONO};white-space:pre-wrap;word-break:break-word;">{_pre(context)}</pre></div>'
+    )
+
+
+# ---------------------------------------------------------------- metrics
+def metrics_panel(emotion, topic, traj_points, delta_text, delta_color, has_traj) -> str:
+    spark = ""
+    if has_traj:
+        spark = (
+            '<div style="background:#f7f9fc;border:1px solid #e6eaf2;border-radius:8px;padding:10px 6px 4px;">'
+            '<svg viewBox="0 0 240 60" preserveAspectRatio="none" style="width:100%;height:56px;display:block;">'
+            '<line x1="0" y1="30" x2="240" y2="30" stroke="#d9e0ec" stroke-width="1" stroke-dasharray="3 3"></line>'
+            f'<polyline points="{traj_points}" fill="none" stroke="{ACCENT}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"></polyline></svg>'
+            f'<div style="display:flex;justify-content:space-between;font:500 9px/1 {MONO};color:#aab2c4;padding:0 4px;"><span>turn 1</span><span>now</span></div></div>'
+        )
+    else:
+        spark = '<div style="font-size:11.5px;color:#aab2c4;">Trajectory appears after two analyzed turns.</div>'
+    return (
+        '<div class="lsa-card">' + _h("SESSION METRICS") +
+        '<div style="display:grid;grid-template-columns:1fr 1fr;gap:9px;margin-bottom:14px;">'
+        '<div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:10px;">'
+        '<div style="font-size:9.5px;color:#8a93a8;letter-spacing:.03em;margin-bottom:5px;">EMOTION</div>'
+        f'<div style="font-weight:600;font-size:14px;color:#28304a;">{esc(emotion)}</div></div>'
+        '<div style="background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:10px;">'
+        '<div style="font-size:9.5px;color:#8a93a8;letter-spacing:.03em;margin-bottom:5px;">TOPIC</div>'
+        f'<div style="font-weight:600;font-size:14px;color:#28304a;">{esc(topic)}</div></div></div>'
+        '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:9px;">'
+        '<span style="font-size:11px;color:#8a93a8;">Sentiment trajectory</span>'
+        f'<span style="font:600 11px/1 {MONO};color:{delta_color};">{esc(delta_text)}</span></div>{spark}</div>'
+    )


### PR DESCRIPTION
## Summary

Makes the app **be** the pixel-perfect Live Session Cockpit design, and wires its typed patient turns to the **real** Python pipeline. Supersedes #24 (which rebuilt the cockpit in native Streamlit).

### Approach
The design is a self-contained React prototype, and Streamlit's static `components.html` can't return data — so the prototype is mounted as a **bidirectional component** (`cockpit_component/`) using the Streamlit postMessage protocol (no build step):

- **Frontend** (`cockpit_component/index.html` + `support.js`): the readable design + React 18 UMD + the dc-runtime + a small Streamlit bridge. Each **patient turn** is POSTed to Python via `setComponentValue`; the real result is applied back (`applyServerArgs`, matched by nonce). The deterministic crisis regex still screens locally for instant feedback; the scripted "Advance" arc stays as the canned demo.
- **Backend** (`app_chat.py`): `declare_component` mounts it full-bleed (100vh, chrome hidden). On a turn it runs `analyze_message` + `generate_session_suggestions`, maps the output (emotion/sentiment/topic, suggestions, RAG cases + context, crisis) into the prototype's shape, and pushes it back. Heavy ML imports are lazy → instant launch screen; failures degrade gracefully.
- `app_live.py`: the native-Streamlit cockpit preserved as a fallback (`streamlit run app_live.py`).

### Verified live (real backend)
A typed crisis phrase produced, from the real pipeline:
- `safety.py` → `suicide_risk` / `CRITICAL` (crisis banner rendered)
- DistilRoBERTa emotion + MiniLM/Pinecone retrieval
- **Real Groq** decision-support (`POST …/chat/completions 200`) → "Feeling hopeless and overwhelmed", suicidal-ideation red flag — rendered in the cockpit.

### Notes
- The BART topic model (~1.6 GB) can fail to load under tight virtual memory (`paging file too small`); the pipeline degrades gracefully (topic→general). Raise the Windows paging file or deploy on a larger box.
- React/ReactDOM load from `unpkg` (the app already needs network for Groq/Pinecone); can be vendored later for an offline build.
- Real patient-record loading from Mongo (overview/timeline from the DB instead of the demo PT-0042 profile) is the natural next increment.

Run: `streamlit run app_chat.py`.