### PR TITLE
Wire real patient loading, profile/history, and session persistence

### DIFF
--- a/app_chat.py
+++ b/app_chat.py
@@ -1,20 +1,25 @@
-"""Streamlit entry point — the Live Session Cockpit prototype WIRED to the real backend.
+"""Streamlit entry point — the Live Session Cockpit, wired to the real backend.
 
 The pixel-perfect design (``cockpit_component/``) is mounted as a bidirectional
-Streamlit component. Typed PATIENT turns are routed to the real Python pipeline —
-deterministic crisis screen (safety.py), emotion/urgency (DistilRoBERTa),
-sentiment (RoBERTa), topic (BART zero-shot), semantic retrieval (MiniLM +
-Pinecone over the Mongo corpus), and Groq decision-support — and the chips,
-decision-support panel, RAG "why" panel, and crisis banner reflect REAL outputs.
+Streamlit component and driven by the real application:
 
-The scripted "Advance" button keeps the canned demo arc (PT-0042). Heavy ML
-imports are lazy, so the launch screen appears instantly; the first analyzed turn
-pays the model-load cost.
+- **Open a patient** (any ID, a persona card, or a recent) loads their real
+  profile + session history from MongoDB into the overview and timeline.
+- **Patient turns** run the real pipeline — deterministic crisis screen, emotion
+  (DistilRoBERTa), sentiment (RoBERTa), topic (BART), semantic retrieval
+  (MiniLM + Pinecone over the corpus), and Groq decision-support.
+- **Sessions persist** — each turn archives the conversation + session log
+  (topics, risk flags, sentiment, doctor notes) to MongoDB.
+- **Recent patients** on the launch screen come from the real ``patients``
+  collection.
 
-The earlier Streamlit-native UI is preserved in ``app_live.py``.
+``PT-0042`` remains the built-in scripted demo. Heavy ML imports are lazy, so
+the launch screen loads instantly. The Streamlit-native UI is preserved in
+``app_live.py``.
 """
 import hmac
 import logging
+import uuid
 from pathlib import Path
 
 import streamlit as st
@@ -33,7 +38,6 @@ st.set_page_config(
     initial_sidebar_state="collapsed",
 )
 
-# Full-bleed: hide Streamlit chrome and stretch the component iframe to the viewport.
 st.markdown(
     """
 <style>
@@ -81,12 +85,10 @@ def check_authentication() -> bool:
 if not check_authentication():
     st.stop()
 
-# Bidirectional component wrapping the prototype.
 _COMPONENT_DIR = Path(__file__).parent / "cockpit_component"
 _lsa_cockpit = components.declare_component("lsa_cockpit", path=str(_COMPONENT_DIR))
 
-# Demo patient profile — matches the cockpit's PT-0042 overview card so the real
-# pipeline's grounding is consistent with what the clinician sees.
+# Profile for the built-in PT-0042 scripted demo (matches its overview card).
 _DEMO_PROFILE = {
     "patient_id": "PT-0042",
     "medical_history": ["generalized anxiety disorder", "panic attacks"],
@@ -102,14 +104,93 @@ def _fmt_score(n) -> str:
     return ("+%.2f" % n) if n >= 0 else ("%.2f" % n)
 
 
-def _run_real_turn(text: str, transcript: str) -> dict:
-    """Run the real analysis + decision-support pipeline for one patient turn and
-    shape it into the payload the prototype's React component expects."""
+# ----------------------------------------------------------------- patient load
+def _roster():
+    """A few real patients from MongoDB for the launch-screen 'recent patients'."""
+    try:
+        from db import get_db
+        from patient_profile import get_patient_sessions
+        from patient_overview import _fmt_date
+        docs = list(get_db()["patients"].find({}, {"patient_id": 1, "_id": 0}).limit(6))
+    except Exception:
+        logger.exception("Failed to load the patient roster")
+        return None
+    out = []
+    for d in docs:
+        pid = d.get("patient_id")
+        if not pid:
+            continue
+        try:
+            sessions = get_patient_sessions(pid)
+        except Exception:
+            sessions = []
+        last = sessions[0] if sessions else None
+        if last:
+            topic = (last.get("detected_topics") or ["session"])[0]
+            out.append({"id": pid, "last": f"{_fmt_date(last.get('created_at'))} · {topic}",
+                        "flag": bool(last.get("risk_flags"))})
+        else:
+            out.append({"id": pid, "last": "no prior sessions", "flag": False})
+    return out or None
+
+
+def _load_patient(pid: str) -> dict:
+    """Load a patient's real profile + history from MongoDB for the cockpit."""
+    from patient_profile import get_patient_profile, get_patient_sessions
+    from patient_overview import _fmt_date, _days_ago
+
+    try:
+        profile = get_patient_profile(pid)
+    except Exception:
+        logger.exception("Patient profile load failed")
+        return {"found": False, "patientId": pid, "error": "Could not reach the patient database."}
+    if profile is None:
+        return {"found": False, "patientId": pid,
+                "error": f"No record found for {pid}. Check the ID, or seed the patient first."}
+
+    prof = profile.dict()
+    try:
+        sessions = get_patient_sessions(pid)
+    except Exception:
+        sessions = []
+
+    last = sessions[0] if sessions else None
+    if last:
+        ago = _days_ago(last.get("created_at"))
+        last_seen = _fmt_date(last.get("created_at")) + (f" · {ago}" if ago else "")
+    else:
+        last_seen = "first session"
+
+    timeline = []
+    for sdoc in sessions[:8]:
+        flags = sdoc.get("risk_flags") or []
+        timeline.append({
+            "date": _fmt_date(sdoc.get("created_at")),
+            "topics": sdoc.get("detected_topics") or [],
+            "score": float(sdoc.get("sentiment_score") or 0.0),
+            "flag": flags[0] if flags else None,
+        })
+
+    patient = {
+        "id": pid,
+        "subtitle": "returning patient" if sessions else "new patient",
+        "sessionCount": len(sessions),
+        "history": prof.get("medical_history") or [],
+        "goals": prof.get("therapy_goals") or [],
+        "lastSeen": last_seen,
+    }
+    return {"found": True, "patient": patient, "timeline": timeline,
+            "session_id": str(uuid.uuid4()), "profile": prof}
+
+
+# ------------------------------------------------------------------ turn + archive
+def _run_real_turn(text: str, transcript: str, profile: dict) -> dict:
+    """Run the real pipeline for one patient turn and shape it for the cockpit."""
     from unified_guidance import analyze_message
     from session_assistant import generate_session_suggestions
     from patient_overview import build_patient_summary
 
-    analysis = analyze_message(text, _DEMO_PROFILE, transcript)
+    analysis = analyze_message(text, profile, transcript)
     urgency = analysis.get("urgency") or {}
     sp = analysis.get("safety_protocol")
 
@@ -127,8 +208,8 @@ def _run_real_turn(text: str, transcript: str) -> dict:
     )
     suggestions = generate_session_suggestions(
         transcript=transcript,
-        patient_summary=build_patient_summary(_DEMO_PROFILE),
-        history_summary="(no prior sessions in this demo)",
+        patient_summary=build_patient_summary(profile),
+        history_summary="(loaded patient record)",
         signals=signals,
         examples=analysis.get("historical_examples"),
         doctor_questions="(see transcript)",
@@ -141,35 +222,54 @@ def _run_real_turn(text: str, transcript: str) -> dict:
         {"k": "Crisis screen", "v": (f"{sp['flag_type']} · {sp['action']}") if sp else "clear"},
     ]
     cases = [
-        {
-            "id": str(ex.get("questionID") or ex.get("id") or "—"),
-            "sim": "",
-            "q": (ex.get("questionText") or "")[:200],
-            "a": (ex.get("answerText") or "")[:200],
-        }
+        {"id": str(ex.get("questionID") or ex.get("id") or "—"), "sim": "",
+         "q": (ex.get("questionText") or "")[:200], "a": (ex.get("answerText") or "")[:200]}
         for ex in (analysis.get("historical_examples") or [])[:3]
     ]
 
     return {
-        "analysis": {
-            "emotion": emotion,
-            "emotionScore": float(e_score),
-            "sentiment": sentiment,
-            "sentimentScore": float(s_score),
-            "topic": topic,
-            "topicConf": float(t_conf),
-        },
-        "suggestions": {
-            k: suggestions.get(k)
-            for k in ("emotional_state", "state_confidence", "red_flags",
-                      "missing_info", "next_questions", "follow_ups", "caveat")
-        },
+        "analysis": {"emotion": emotion, "emotionScore": float(e_score), "sentiment": sentiment,
+                     "sentimentScore": float(s_score), "topic": topic, "topicConf": float(t_conf)},
+        "suggestions": {k: suggestions.get(k) for k in
+                        ("emotional_state", "state_confidence", "red_flags",
+                         "missing_info", "next_questions", "follow_ups", "caveat")},
         "why": {"signals": why_signals, "cases": cases,
                 "context": analysis.get("analysis_context") or ""},
         "crisis": ({"flag_type": sp["flag_type"], "action": sp["action"], "response": sp["response"]}
                    if sp else None),
         "errors": analysis.get("errors") or [],
     }
+
+
+def _archive(active: dict, messages, notes: str, result: dict) -> None:
+    """Persist the conversation + session log for the active patient session."""
+    from archiver import archive_conversation, archive_session
+    from schemas import Conversation, Message, SessionLog
+    try:
+        conv = Conversation(
+            session_id=active["session_id"], patient_id=active["patient_id"],
+            messages=[Message(content=m.get("text", ""),
+                              is_user=(m.get("speaker") == "patient"),
+                              speaker=m.get("speaker", "patient")) for m in (messages or [])],
+        )
+        archive_conversation(conv)
+
+        topic = (result.get("analysis") or {}).get("topic")
+        if topic and topic not in active["topics"]:
+            active["topics"].append(topic)
+        crisis = result.get("crisis")
+        if crisis and crisis.get("flag_type") and crisis["flag_type"] not in active["risk_flags"]:
+            active["risk_flags"].append(crisis["flag_type"])
+
+        archive_session(SessionLog(
+            session_id=active["session_id"], patient_id=active["patient_id"],
+            detected_topics=active["topics"], risk_flags=active["risk_flags"],
+            sentiment_score=float((result.get("analysis") or {}).get("sentimentScore") or 0.0),
+            doctor_notes=notes or "", suggestions=[],
+        ))
+    except Exception:
+        logger.exception("Session archival failed")
+        st.session_state["lsa_archive_failed"] = True
 
 
 _ERROR_RESULT = {
@@ -182,19 +282,52 @@ _ERROR_RESULT = {
     "crisis": None,
 }
 
-# Render the component, passing the most recent result back to the iframe.
-payload = _lsa_cockpit(result=st.session_state.get("lsa_result"), key="lsa_cockpit", default=None)
+# --------------------------------------------------------------------- main loop
+if "lsa_roster" not in st.session_state:
+    st.session_state["lsa_roster"] = _roster()
 
-# A new patient turn arrived from the iframe — run the real pipeline and push it back.
-if isinstance(payload, dict) and payload.get("kind") == "patient_turn":
+payload = _lsa_cockpit(
+    result=st.session_state.get("lsa_result"),
+    roster=st.session_state.get("lsa_roster"),
+    key="lsa_cockpit",
+    default=None,
+)
+
+if isinstance(payload, dict):
     nonce = payload.get("nonce")
+    kind = payload.get("kind")
     if nonce is not None and nonce != st.session_state.get("lsa_handled_nonce"):
         st.session_state["lsa_handled_nonce"] = nonce
-        try:
-            result = _run_real_turn(payload.get("text", ""), payload.get("transcript", ""))
-        except Exception:
-            logger.exception("Real pipeline failed for a patient turn")
-            result = dict(_ERROR_RESULT)
-        result["nonce"] = nonce
-        st.session_state["lsa_result"] = result
-        st.rerun()
+
+        if kind == "open":
+            loaded = _load_patient((payload.get("patientId") or "").strip().upper())
+            result = {"nonce": nonce, "kind": "open", "found": loaded["found"]}
+            if loaded["found"]:
+                result["patient"] = loaded["patient"]
+                result["timeline"] = loaded["timeline"]
+                st.session_state["lsa_active"] = {
+                    "patient_id": loaded["patient"]["id"],
+                    "session_id": loaded["session_id"],
+                    "profile": loaded["profile"],
+                    "risk_flags": [], "topics": [],
+                }
+            else:
+                result["patientId"] = loaded.get("patientId")
+                result["error"] = loaded.get("error")
+            st.session_state["lsa_result"] = result
+            st.rerun()
+
+        elif kind == "patient_turn":
+            active = st.session_state.get("lsa_active")
+            profile = active["profile"] if active else _DEMO_PROFILE
+            try:
+                result = _run_real_turn(payload.get("text", ""), payload.get("transcript", ""), profile)
+            except Exception:
+                logger.exception("Real pipeline failed for a patient turn")
+                result = dict(_ERROR_RESULT)
+            result["nonce"] = nonce
+            result["kind"] = "turn"
+            if active:  # real patient (not the in-memory demo) -> persist
+                _archive(active, payload.get("messages"), payload.get("notes", ""), result)
+            st.session_state["lsa_result"] = result
+            st.rerun()

--- a/cockpit_component/index.html
+++ b/cockpit_component/index.html
@@ -144,7 +144,7 @@
 
     <div style="display:flex;align-items:center;gap:8px;margin-left:6px;padding:5px 11px;background:#f4f6fa;border:1px solid #e3e8f2;border-radius:8px;">
       <span style="font:500 11px/1 'IBM Plex Mono',monospace;color:#8a93a8;">PATIENT</span>
-      <span style="font:600 13px/1 'IBM Plex Mono',monospace;color:#1a2235;letter-spacing:.01em;">PT-0042</span>
+      <span style="font:600 13px/1 'IBM Plex Mono',monospace;color:#1a2235;letter-spacing:.01em;">{{ patientId }}</span>
       <span style="width:6px;height:6px;border-radius:50%;background:#2f8f6b;margin-left:2px;box-shadow:0 0 0 3px rgba(47,143,107,.16);"></span>
       <span style="font-size:11.5px;font-weight:600;color:#2f8f6b;">Session live</span>
     </div>
@@ -178,12 +178,12 @@
 
         <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;">
           <div>
-            <div style="font:600 19px/1 'IBM Plex Mono',monospace;letter-spacing:.01em;">PT-0042</div>
-            <div style="font-size:12.5px;color:#647089;margin-top:4px;">34 · returning patient</div>
+            <div style="font:600 19px/1 'IBM Plex Mono',monospace;letter-spacing:.01em;">{{ patientId }}</div>
+            <div style="font-size:12.5px;color:#647089;margin-top:4px;">{{ patientSubtitle }}</div>
           </div>
           <div style="display:flex;gap:8px;">
             <div style="text-align:center;background:#f4f6fa;border:1px solid #e6eaf2;border-radius:8px;padding:7px 10px;">
-              <div style="font:600 17px/1 'IBM Plex Mono',monospace;">3</div>
+              <div style="font:600 17px/1 'IBM Plex Mono',monospace;">{{ patientSessions }}</div>
               <div style="font-size:9.5px;color:#8a93a8;margin-top:3px;letter-spacing:.02em;">SESSIONS</div>
             </div>
           </div>
@@ -192,22 +192,24 @@
         <div style="margin-top:15px;">
           <div style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;margin-bottom:7px;">CLINICAL HISTORY</div>
           <div style="display:flex;flex-wrap:wrap;gap:6px;">
-            <span style="font:500 11.5px/1 'IBM Plex Mono',monospace;background:#f0f3f9;color:#4a5670;padding:5px 8px;border-radius:6px;">generalized anxiety disorder</span>
-            <span style="font:500 11.5px/1 'IBM Plex Mono',monospace;background:#f0f3f9;color:#4a5670;padding:5px 8px;border-radius:6px;">panic attacks</span>
+            <sc-for list="{{ patientHistory }}" as="h" hint-placeholder-count="2">
+              <span style="font:500 11.5px/1 'IBM Plex Mono',monospace;background:#f0f3f9;color:#4a5670;padding:5px 8px;border-radius:6px;">{{ h }}</span>
+            </sc-for>
           </div>
         </div>
 
         <div style="margin-top:14px;">
           <div style="font-size:10.5px;font-weight:600;color:#8a93a8;letter-spacing:.04em;margin-bottom:7px;">THERAPY GOALS</div>
           <ul style="margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:6px;">
-            <li style="display:flex;gap:8px;font-size:13px;color:#3a4458;"><span style="color:{{ accent }};">›</span>reduce daily anxiety</li>
-            <li style="display:flex;gap:8px;font-size:13px;color:#3a4458;"><span style="color:{{ accent }};">›</span>manage panic episodes</li>
+            <sc-for list="{{ patientGoals }}" as="g" hint-placeholder-count="2">
+              <li style="display:flex;gap:8px;font-size:13px;color:#3a4458;"><span style="color:{{ accent }};">›</span>{{ g }}</li>
+            </sc-for>
           </ul>
         </div>
 
         <div style="margin-top:15px;padding-top:13px;border-top:1px dashed #e3e8f2;display:flex;justify-content:space-between;font-size:12px;">
           <span style="color:#8a93a8;">Last seen</span>
-          <span style="font-weight:600;color:#3a4458;font-family:'IBM Plex Mono',monospace;">2026-05-28 · 25d ago</span>
+          <span style="font-weight:600;color:#3a4458;font-family:'IBM Plex Mono',monospace;">{{ patientLastSeen }}</span>
         </div>
       </div>
 
@@ -501,7 +503,7 @@
         <div style="position:sticky;top:0;background:#fff;padding:20px 24px 16px;border-bottom:1px solid #eef1f6;display:flex;align-items:center;justify-content:space-between;">
           <div>
             <div style="font-weight:700;font-size:17px;">End-of-session report</div>
-            <div style="font:500 11px/1 'IBM Plex Mono',monospace;color:#8a93a8;margin-top:5px;">PT-0042 · {{ clock }} · {{ turnCount }} turns logged</div>
+            <div style="font:500 11px/1 'IBM Plex Mono',monospace;color:#8a93a8;margin-top:5px;">{{ patientId }} · {{ clock }} · {{ turnCount }} turns logged</div>
           </div>
           <button onClick="{{ closeReport }}" style="cursor:pointer;border:1px solid #e3e8f2;background:#f4f6fa;width:30px;height:30px;border-radius:8px;font-size:16px;color:#647089;">×</button>
         </div>
@@ -672,10 +674,21 @@ class Component extends DCLogic {
       view: "launch",
       launchId: "PT-0042",
       launchError: "",
+      loadingPatient: false,
       trajectory: [-0.54],
       elapsed: 0,
       stages: this.doneStages(false),
       running: false,
+      // Patient context — defaults to the PT-0042 demo; replaced by the real
+      // record (from MongoDB) when a non-demo patient is opened.
+      patient: {
+        id: "PT-0042", subtitle: "34 · returning patient", sessionCount: 3,
+        history: ["generalized anxiety disorder", "panic attacks"],
+        goals: ["reduce daily anxiety", "manage panic episodes"],
+        lastSeen: "2026-05-28 · 25d ago",
+      },
+      realTimeline: null,  // null -> use the demo timeline; array -> real prior sessions
+      roster: null,        // null -> demo recents; array -> real recent patients
     };
   }
 
@@ -872,7 +885,12 @@ class Component extends DCLogic {
       suggestions: null, why: null, whyOpen: null, running: true,
     }));
     if (window.Streamlit && window.Streamlit.setComponentValue) {
-      window.Streamlit.setComponentValue({ nonce: nonce, kind: "patient_turn", text: text, transcript: transcript });
+      const msgs = this.state.messages.concat([{ speaker: "patient", text: text }])
+        .map(m => ({ speaker: m.speaker, text: m.text }));
+      window.Streamlit.setComponentValue({
+        nonce: nonce, kind: "patient_turn", text: text, transcript: transcript,
+        messages: msgs, notes: this.state.notes,
+      });
     } else {
       // Fallback to the local mock pipeline when opened outside Streamlit.
       const crisis = this.checkSafety(text);
@@ -880,12 +898,34 @@ class Component extends DCLogic {
     }
   };
 
-  // Apply a real pipeline result pushed from Python (matched by nonce).
+  // Apply server pushes from Python: the real recent-patient roster, a patient
+  // record (open), or a turn's analysis — all matched by nonce.
   applyServerArgs(args) {
-    if (!args || !args.result) return;
+    if (!args) return;
+    if (args.roster && !this._rosterSet) { this._rosterSet = true; this.setState({ roster: args.roster }); }
     const r = args.result;
-    if (r.nonce == null || r.nonce !== this._pendingNonce) return;
+    if (!r || r.nonce == null || r.nonce !== this._pendingNonce) return;
     this._pendingNonce = null;
+
+    if (r.kind === "open") {
+      if (!r.found) {
+        this.setState({ loadingPatient: false, launchError: r.error || ("No record found for " + (r.patientId || "that patient") + ".") });
+        return;
+      }
+      this._start = Date.now();
+      try { localStorage.setItem("lsa-session-start", String(this._start)); } catch (e) {}
+      // Start a fresh real session for the loaded patient (no scripted seed).
+      this.setState({
+        view: "session", elapsed: 0, launchError: "", loadingPatient: false,
+        patient: r.patient, realTimeline: r.timeline || [],
+        messages: [], suggestions: null, why: null, whyOpen: null,
+        crisisActive: null, trajectory: [], scriptIndex: this.SCRIPT.length,
+        stages: this.stageDefs().map(x => ({ ...x, status: "pending" })), running: false,
+      });
+      return;
+    }
+
+    // Default: a turn analysis result.
     const isCrisis = !!r.crisis;
     this.setState({ stages: this.doneStages(isCrisis), crisisActive: r.crisis || this.state.crisisActive });
     this.finishPipeline({ analysis: r.analysis, suggestions: r.suggestions, why: r.why, crisis: r.crisis || null });
@@ -912,12 +952,26 @@ class Component extends DCLogic {
     try { localStorage.setItem("lsa-session-start", String(this._start)); } catch (e) {}
     this.setState({ view: "session", elapsed: 0, launchError: "" });
   };
+  // Load a real patient from MongoDB via the backend, then open their session.
+  openPatient = (id) => {
+    const pid = (id || "").trim().toUpperCase();
+    if (!pid) { this.setState({ launchError: "Enter a patient ID to continue." }); return; }
+    if (window.Streamlit && window.Streamlit.setComponentValue) {
+      const nonce = (this._nonce = (this._nonce || 0) + 1);
+      this._pendingNonce = nonce;
+      this.setState({ loadingPatient: true, launchError: "", launchId: pid });
+      window.Streamlit.setComponentValue({ nonce: nonce, kind: "open", patientId: pid });
+    } else {
+      this.setState({ launchError: "Loading a real patient requires the backend." });
+    }
+  };
   submitLaunch = () => {
     const id = (this.state.launchId || "").trim().toUpperCase();
-    if (id === "PT-0042") this.openSession();
-    else this.setState({ launchError: id ? `No scripted scenario for ${id} in this prototype — try PT-0042.` : "Enter a patient ID to continue." });
+    if (!id) { this.setState({ launchError: "Enter a patient ID to continue." }); return; }
+    if (id === "PT-0042") this.openSession();  // built-in scripted demo
+    else this.openPatient(id);
   };
-  seededNote = () => this.setState({ launchError: "Only PT-0042 has a scripted scenario in this prototype. The other patients are seeded for the real app." });
+  seededNote = () => this.openPatient(this.state.launchId);
   onLaunchId = (e) => this.setState({ launchId: e.target.value, launchError: "" });
   onLaunchKey = (e) => { if (e.key === "Enter") { e.preventDefault(); this.submitLaunch(); } };
   backToLaunch = () => this.setState({ view: "launch" });
@@ -935,17 +989,20 @@ class Component extends DCLogic {
     // ---- launch screen: personas + recents ----
     const pStyle = (en) => `cursor:pointer;text-align:left;border:${en ? "1.5px solid " + accent : "1px solid #e6eaf2"};background:${en ? accentSoft : "#fbfcfe"};border-radius:11px;padding:13px;font-family:inherit;${en ? "" : "opacity:.82;"}`;
     const pMeta = (en) => `font:600 9px/1 'IBM Plex Mono',monospace;letter-spacing:.04em;padding:3px 7px;border-radius:5px;${en ? `background:${accent};color:#fff;` : "background:#eef1f6;color:#8a93a8;"}`;
+    const openByCard = (id) => (id === "PT-0042" ? this.openSession : (() => this.openPatient(id)));
     const personas = [
-      { id: "PT-0042", label: "Anxiety & panic", desc: "GAD · panic attacks", meta: "demo ready", en: true },
+      { id: "PT-0042", label: "Anxiety & panic", desc: "GAD · panic attacks", meta: "demo", en: true },
       { id: "PT-0017", label: "Depression", desc: "MDD · low mood", meta: "seeded", en: false },
       { id: "PT-0008", label: "Grief & loss", desc: "recent bereavement", meta: "seeded", en: false },
       { id: "PT-0023", label: "Trauma / PTSD", desc: "hypervigilance", meta: "seeded", en: false },
-    ].map(p => ({ ...p, style: pStyle(p.en), metaStyle: pMeta(p.en), onClick: p.en ? this.openSession : this.seededNote }));
-    const recents = [
-      { id: "PT-0042", last: "today · panic recurrence", flag: false, en: true },
-      { id: "PT-0031", last: "2026-06-12 · routine review", flag: false, en: false },
-      { id: "PT-0009", last: "2026-06-05 · risk flagged", flag: true, en: false },
-    ].map(r => ({ ...r, style: `cursor:pointer;display:flex;align-items:center;width:100%;text-align:left;border:none;background:transparent;padding:10px 6px;font-family:inherit;${r.en ? "" : "opacity:.72;"}`, onClick: r.en ? this.openSession : this.seededNote, arrow: r.en ? "›" : "" }));
+    ].map(p => ({ ...p, style: pStyle(p.en), metaStyle: pMeta(p.en), onClick: openByCard(p.id) }));
+    // Real recent patients from MongoDB when available; otherwise the demo list.
+    const recentRows = (this.state.roster && this.state.roster.length) ? this.state.roster : [
+      { id: "PT-0042", last: "today · panic recurrence (demo)", flag: false },
+      { id: "PT-0031", last: "2026-06-12 · routine review", flag: false },
+      { id: "PT-0009", last: "2026-06-05 · risk flagged", flag: true },
+    ];
+    const recents = recentRows.map(r => ({ ...r, style: `cursor:pointer;display:flex;align-items:center;width:100%;text-align:left;border:none;background:transparent;padding:10px 6px;font-family:inherit;`, onClick: openByCard(r.id), arrow: "›" }));
     const sg = this.state.suggestions || {};
     const s = this.state;
 
@@ -992,13 +1049,17 @@ class Component extends DCLogic {
       { date: "2026-04-30", topics: ["stress", "anxiety"], score: -0.61, flag: null },
       { date: "2026-03-18", topics: ["anxiety", "panic"], score: -0.78, flag: "suicide_risk" },
     ];
-    const timeline = tlRaw.map((t, i) => ({
-      date: t.date, topics: t.topics, score: this.fmtScore(t.score),
-      scoreStyle: `color:${t.score < -0.6 ? "#b23a31" : t.score < -0.3 ? "#b5862f" : "#647089"};`,
-      dotStyle: `width:10px;height:10px;border-radius:50%;flex:none;margin-top:3px;background:${t.flag ? "#c2362f" : i === 0 ? accent : "#c2cad8"};`,
-      lineStyle: i === tlRaw.length - 1 ? "display:none;" : "flex:1;width:1.5px;background:#e6eaf2;margin:3px 0;",
-      hasFlag: !!t.flag, flagText: t.flag ? "risk: " + t.flag : "",
-    }));
+    const tlSource = (s.realTimeline != null) ? s.realTimeline : tlRaw;
+    const timeline = tlSource.map((t, i) => {
+      const score = (typeof t.score === "number") ? t.score : 0;
+      return {
+        date: t.date, topics: t.topics || [], score: this.fmtScore(score),
+        scoreStyle: `color:${score < -0.6 ? "#b23a31" : score < -0.3 ? "#b5862f" : "#647089"};`,
+        dotStyle: `width:10px;height:10px;border-radius:50%;flex:none;margin-top:3px;background:${t.flag ? "#c2362f" : i === 0 ? accent : "#c2cad8"};`,
+        lineStyle: i === tlSource.length - 1 ? "display:none;" : "flex:1;width:1.5px;background:#e6eaf2;margin:3px 0;",
+        hasFlag: !!t.flag, flagText: t.flag ? "risk: " + t.flag : "",
+      };
+    });
 
     // pipeline stage views
     const stageStyle = (st) => {
@@ -1089,6 +1150,13 @@ class Component extends DCLogic {
       isLaunch: s.view === "launch", isSession: s.view === "session",
       launchId: s.launchId, launchError: s.launchError, hasLaunchError: !!s.launchError,
       personas, recents,
+      // Patient context (real record or PT-0042 demo).
+      patientId: (s.patient || {}).id || "—",
+      patientSubtitle: (s.patient || {}).subtitle || "",
+      patientSessions: ((s.patient || {}).sessionCount != null ? (s.patient || {}).sessionCount : 0),
+      patientHistory: (s.patient || {}).history || [],
+      patientGoals: (s.patient || {}).goals || [],
+      patientLastSeen: (s.patient || {}).lastSeen || "—",
       submitLaunch: this.submitLaunch, onLaunchId: this.onLaunchId, onLaunchKey: this.onLaunchKey, backToLaunch: this.backToLaunch,
       clock: `${mm}:${ss}`,
       msgViews, timeline,


### PR DESCRIPTION
## Summary

Completes the cockpit into a **fully functional app** — fixing the "No scripted scenario for PT-0001…" gate. Any patient now loads their real MongoDB record, turns run against that record, and sessions persist.

### Component (`cockpit_component/index.html`)
- **Open any patient** — `submitLaunch` / the persona cards / the recent rows POST `{kind:"open", patientId}` to Python via the bridge (instead of the demo-only PT-0042 gate).
- **`applyServerArgs`** handles three server pushes — the real recent-patient **roster**, a **patient-open** result (sets overview/timeline, starts a fresh session), and a **turn** analysis — matched by nonce. Unknown ID → "no record found".
- **Patient overview** (id, subtitle, session count, clinical history, therapy goals, last seen), the **header pill**, and the **session-history timeline** are now data-bound to the loaded record (were hardcoded PT-0042).
- Turn payloads carry the full transcript + doctor notes for archival.
- `PT-0042` stays the built-in scripted demo.

### Backend (`app_chat.py`)
- `_roster()` — real recent patients from the `patients` collection for the launch screen.
- `_load_patient()` — loads profile + session history and shapes the overview + timeline; "not found" → clear error.
- Patient turns run against the **loaded patient's real profile**, and each turn **archives** the conversation + session log (topics, risk flags, sentiment, doctor notes) to MongoDB.

### Verified live (seeded DB)
- Launch screen lists real patients (`PT-0001 · anxiety`, `PT-0002 · stress`, …).
- Opening **PT-0001** loads its real profile (`disrupted sleep, chronic insomnia` / goals `improve sleep…`) and its 2 prior sessions into the timeline.
- A typed turn → real Groq decision-support ("anxious and sleep-deprived", red flags, next questions) and writes a `Conversation` + `SessionLog` to MongoDB (`archiver: … archived successfully`).

### Notes
- The BART topic model can still OOM under tight virtual memory; the pipeline degrades gracefully.
- Real end-of-session **Groq report narrative** (the modal already summarizes real signals) is a small optional follow-up.

Run: `streamlit run app_chat.py`.