### PR TITLE
Doctor-facing "Ask" assistant for grounded session questions

### DIFF
--- a/app_chat.py
+++ b/app_chat.py
@@ -331,3 +331,23 @@ if isinstance(payload, dict):
                 _archive(active, payload.get("messages"), payload.get("notes", ""), result)
             st.session_state["lsa_result"] = result
             st.rerun()
+
+        elif kind == "doctor_query":
+            # "Ask" mode: answer a clinician's free-form question grounded in the
+            # patient's record + sessions + corpus. Read-only (no archival).
+            active = st.session_state.get("lsa_active")
+            question = (payload.get("question") or "").strip()
+            if not question:
+                text = "Please enter a question for the assistant."
+            elif not active:  # PT-0042 demo opens client-side; no real record loaded
+                text = ("Open a real patient (e.g. PT-0001) to ask record-grounded questions. "
+                        "The scripted PT-0042 demo has no database-backed record.")
+            else:
+                try:
+                    from doctor_qa import answer_doctor_query
+                    text = answer_doctor_query(question, active, payload.get("transcript", ""))
+                except Exception:
+                    logger.exception("Doctor query failed")
+                    text = "The assistant could not answer that just now. Please try again."
+            st.session_state["lsa_result"] = {"nonce": nonce, "kind": "answer", "text": text}
+            st.rerun()

--- a/cockpit_component/index.html
+++ b/cockpit_component/index.html
@@ -294,7 +294,7 @@
               <sc-if value="{{ m.pending }}" hint-placeholder-val="{{ false }}">
                 <div style="display:flex;align-items:center;gap:7px;animation:softpulse 1.1s ease-in-out infinite;">
                   <span style="width:6px;height:6px;border-radius:50%;background:#aab2c4;"></span>
-                  <span style="font:500 11px/1 'IBM Plex Mono',monospace;color:#aab2c4;">analyzing turn…</span>
+                  <span style="font:500 11px/1 'IBM Plex Mono',monospace;color:#aab2c4;">{{ m.pendingLabel }}</span>
                 </div>
               </sc-if>
               <sc-if value="{{ m.hasChips }}" hint-placeholder-val="{{ false }}">
@@ -314,6 +314,7 @@
             <div style="display:flex;background:#eef1f6;border-radius:8px;padding:3px;flex:none;">
               <button onClick="{{ setSpeakerPatient }}" style="{{ patientTabStyle }}">Patient</button>
               <button onClick="{{ setSpeakerDoctor }}" style="{{ doctorTabStyle }}">Doctor</button>
+              <button onClick="{{ setSpeakerAsk }}" style="{{ askTabStyle }}">Ask</button>
             </div>
             <textarea onInput="{{ onDraft }}" onKeyDown="{{ onComposerKey }}" value="{{ draft }}" placeholder="{{ composerPlaceholder }}" style="flex:1;min-height:42px;max-height:120px;resize:none;border:1px solid #dde3ee;border-radius:8px;padding:11px 12px;font-family:inherit;font-size:13.5px;color:#1a2235;outline:none;line-height:1.45;"></textarea>
             <button onClick="{{ send }}" style="cursor:pointer;border:none;background:{{ accent }};color:#fff;font-family:inherit;font-weight:600;font-size:13px;height:42px;padding:0 16px;border-radius:8px;flex:none;">Log turn</button>
@@ -873,6 +874,26 @@ class Component extends DCLogic {
       this.setState(s => ({ messages: s.messages.concat([{ id: this.uid(), speaker: "doctor", text, time: now }]), draft: "" }));
       return;
     }
+    if (this.state.speaker === "ask") {
+      // "Ask" mode: pose a grounded question to the backend assistant.
+      const qnonce = (this._nonce = (this._nonce || 0) + 1);
+      this._pendingNonce = qnonce;
+      const qtranscript = this.state.messages.map(m => this.cap(m.speaker) + ": " + m.text).join("\n");
+      this.setState(s => ({
+        messages: s.messages.concat([
+          { id: this.uid(), speaker: "doctor", text, time: now },
+          { id: this.uid(), speaker: "assistant", text: "", time: now, pending: true },
+        ]),
+        draft: "", running: true,
+      }));
+      if (window.Streamlit && window.Streamlit.setComponentValue) {
+        window.Streamlit.setComponentValue({ nonce: qnonce, kind: "doctor_query", question: text, transcript: qtranscript });
+      } else {
+        setTimeout(() => this.applyServerArgs({ result: { nonce: qnonce, kind: "answer",
+          text: "(demo) The backend isn't connected, so I can't pull the record." } }), 300);
+      }
+      return;
+    }
     // Patient turn: route to the REAL Python pipeline via the Streamlit bridge.
     const nonce = (this._nonce = (this._nonce || 0) + 1);
     this._pendingNonce = nonce;
@@ -886,6 +907,7 @@ class Component extends DCLogic {
     }));
     if (window.Streamlit && window.Streamlit.setComponentValue) {
       const msgs = this.state.messages.concat([{ speaker: "patient", text: text }])
+        .filter(m => m.speaker !== "assistant")  // keep Q&A out of the archived record
         .map(m => ({ speaker: m.speaker, text: m.text }));
       window.Streamlit.setComponentValue({
         nonce: nonce, kind: "patient_turn", text: text, transcript: transcript,
@@ -925,6 +947,21 @@ class Component extends DCLogic {
       return;
     }
 
+    if (r.kind === "answer") {
+      // Resolve the pending "Assistant" bubble in place with the grounded answer.
+      this.setState(s => {
+        const msgs = s.messages.slice();
+        for (let j = msgs.length - 1; j >= 0; j--) {
+          if (msgs[j].speaker === "assistant" && msgs[j].pending) {
+            msgs[j] = { ...msgs[j], pending: false, text: r.text || "(no answer)" };
+            break;
+          }
+        }
+        return { messages: msgs, running: false };
+      });
+      return;
+    }
+
     // Default: a turn analysis result.
     const isCrisis = !!r.crisis;
     this.setState({ stages: this.doneStages(isCrisis), crisisActive: r.crisis || this.state.crisisActive });
@@ -942,6 +979,7 @@ class Component extends DCLogic {
   };
   setSpeakerPatient = () => this.setState({ speaker: "patient" });
   setSpeakerDoctor = () => this.setState({ speaker: "doctor" });
+  setSpeakerAsk = () => this.setState({ speaker: "ask" });
   toggleWhy = () => this.setState(s => ({ whyOpen: !this.whyEffective() }));
   openReport = () => this.setState({ reportOpen: true });
   closeReport = () => this.setState({ reportOpen: false });
@@ -1014,10 +1052,14 @@ class Component extends DCLogic {
     const chip = (text, bg, color) => ({ text, style: `font:500 10.5px/1 'IBM Plex Mono',monospace;padding:4px 7px;border-radius:5px;background:${bg};color:${color};letter-spacing:.02em;` });
     const msgViews = s.messages.map(m => {
       const isP = m.speaker === "patient";
+      const isA = m.speaker === "assistant";
       const isCrisisMsg = !!m.crisis;
       const bubbleBase = "font-size:13.5px;line-height:1.55;padding:11px 13px;border-radius:10px;max-width:88%;";
       let bubbleStyle, labelStyle;
-      if (!isP) {
+      if (isA) {
+        bubbleStyle = bubbleBase + `background:${accentSoft};border:1px solid ${this.hexRgba(accent, 0.35)};color:#26365e;border-top-left-radius:3px;`;
+        labelStyle = `font:600 10px/1 'IBM Plex Mono',monospace;letter-spacing:.05em;color:${accent};text-transform:uppercase;`;
+      } else if (!isP) {
         bubbleStyle = bubbleBase + "background:#f4f6fa;border:1px solid #e6eaf2;color:#2a3450;border-top-left-radius:3px;";
         labelStyle = "font:600 10px/1 'IBM Plex Mono',monospace;letter-spacing:.05em;color:#8a93a8;text-transform:uppercase;";
       } else if (isCrisisMsg) {
@@ -1036,10 +1078,11 @@ class Component extends DCLogic {
         chips.push(chip(a.topic, "#eaf0fd", "#3052b8"));
       }
       return {
-        id: m.id, who: isP ? "Patient" : "Doctor", time: m.time, text: m.text,
+        id: m.id, who: isA ? "Assistant" : (isP ? "Patient" : "Doctor"), time: m.time, text: m.text,
         rowStyle: "display:flex;flex-direction:column;gap:7px;animation:fadeUp .3s ease;",
         labelStyle, bubbleStyle,
-        pending: !!m.pending, hasChips: chips.length > 0, chips,
+        pending: !!m.pending, pendingLabel: isA ? "assistant is thinking…" : "analyzing turn…",
+        hasChips: chips.length > 0, chips,
       };
     });
 
@@ -1115,7 +1158,8 @@ class Component extends DCLogic {
     const tabBase = "cursor:pointer;border:none;font-family:inherit;font-weight:600;font-size:12px;padding:7px 13px;border-radius:6px;";
     const patientTabStyle = tabBase + (s.speaker === "patient" ? `background:${accent};color:#fff;` : "background:transparent;color:#7a849c;");
     const doctorTabStyle = tabBase + (s.speaker === "doctor" ? `background:${accent};color:#fff;` : "background:transparent;color:#7a849c;");
-    const composerPlaceholder = s.speaker === "patient" ? "Log the patient's words… (try a phrase like \u201cI don't want to live\u201d)" : "Log your question to the patient…";
+    const askTabStyle = tabBase + (s.speaker === "ask" ? `background:${accent};color:#fff;` : "background:transparent;color:#7a849c;");
+    const composerPlaceholder = s.speaker === "ask" ? "Ask the assistant… (e.g. previous-session details, history, risk flags)" : s.speaker === "patient" ? "Log the patient's words… (try a phrase like \u201cI don't want to live\u201d)" : "Log your question to the patient…";
 
     // advance button
     const scriptDone = this.state.scriptIndex >= this.SCRIPT.length;
@@ -1184,7 +1228,7 @@ class Component extends DCLogic {
 
       // composer
       draft: s.draft, notes: s.notes,
-      patientTabStyle, doctorTabStyle, composerPlaceholder, advanceStyle, advanceHint,
+      patientTabStyle, doctorTabStyle, askTabStyle, composerPlaceholder, advanceStyle, advanceHint,
 
       // report modal
       reportOpen: s.reportOpen, report,
@@ -1192,6 +1236,7 @@ class Component extends DCLogic {
       // handlers
       advance: this.advance, send: this.send, onDraft: this.onDraft, onComposerKey: this.onComposerKey,
       onNotes: this.onNotes, setSpeakerPatient: this.setSpeakerPatient, setSpeakerDoctor: this.setSpeakerDoctor,
+      setSpeakerAsk: this.setSpeakerAsk,
       toggleWhy: this.toggleWhy, openReport: this.openReport, closeReport: this.closeReport, stop: this.stop,
       scrollRef: this.scrollRef,
     };

--- a/doctor_qa.py
+++ b/doctor_qa.py
@@ -1,0 +1,123 @@
+"""Doctor-facing query assistant.
+
+Answers a clinician's free-form question during a live session, grounded in the
+patient record, prior sessions (incl. their archived transcripts, excluding
+today's), the live session so far + accumulated signals, and the RAG knowledge
+corpus. One general LLM-with-context engine — no per-question hardcoding.
+
+Read-only: it never writes to the database. Returns a concise markdown answer.
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+_MAX_LIVE_CHARS = 6000
+_MAX_PRIOR_MSGS = 30
+
+
+def _prior_transcript(pid: str, session_id: str) -> str:
+    """The archived transcript of the patient's most recent prior session."""
+    from patient_profile import get_patient_conversations
+    try:
+        convs = get_patient_conversations(pid)
+    except Exception:
+        logger.exception("Failed to load prior conversations")
+        return "(transcript unavailable)"
+    conv = next((c for c in convs if c.get("session_id") == session_id), None)
+    if not conv:
+        return "(transcript for the previous session is not archived)"
+    lines = []
+    for m in (conv.get("messages") or [])[-_MAX_PRIOR_MSGS:]:
+        speaker = m.get("speaker") or ("patient" if m.get("is_user") else "doctor")
+        lines.append(f"{speaker.capitalize()}: {(m.get('content') or '')[:300]}")
+    return "\n".join(lines) or "(empty transcript)"
+
+
+def _retrieved_cases(question: str) -> str:
+    """Top corpus cases for the question (graceful if Pinecone is unavailable)."""
+    from semantic_search import semantic_search
+    try:
+        cases = semantic_search(question, top_k=3)
+    except Exception:
+        logger.exception("Corpus retrieval failed")
+        return "(knowledge base unavailable)"
+    if not cases:
+        return "(no closely related cases found)"
+    return "\n".join(
+        f"- [corpus #{ex.get('questionID')}] Q: {(ex.get('questionText') or '')[:200]} "
+        f"| A: {(ex.get('answerText') or '')[:300]}"
+        for ex in cases
+    )
+
+
+def _clip_live(transcript: str) -> str:
+    t = transcript or "(no turns logged yet)"
+    if len(t) <= _MAX_LIVE_CHARS:
+        return t
+    return t[:1500] + "\n…[earlier turns omitted]…\n" + t[-4000:]
+
+
+def answer_doctor_query(question: str, active: dict, transcript: str) -> str:
+    """Answer the clinician's question grounded in the patient's data + corpus.
+
+    ``active`` is ``st.session_state['lsa_active']`` =
+    ``{patient_id, session_id, profile(dict), risk_flags, topics}``.
+    """
+    from langchain.schema import HumanMessage
+    from model_cache import get_chat_groq
+    from prompt_templates import DOCTOR_QA_TEMPLATE
+    from patient_profile import get_patient_sessions
+    from patient_overview import build_patient_summary, build_history_summary, _fmt_date, _days_ago
+
+    pid = active.get("patient_id")
+    profile = active.get("profile") or {}
+    cur_session_id = active.get("session_id")
+
+    # Prior sessions, excluding today's in-progress session.
+    try:
+        sessions = get_patient_sessions(pid)
+    except Exception:
+        logger.exception("Failed to load patient sessions")
+        sessions = []
+    prior = [s for s in sessions if s.get("session_id") != cur_session_id]
+
+    last = prior[0] if prior else None
+    if last:
+        ago = _days_ago(last.get("created_at"))
+        date = _fmt_date(last.get("created_at")) + (f" ({ago})" if ago else "")
+        topics = ", ".join(last.get("detected_topics") or []) or "—"
+        flags = ", ".join(last.get("risk_flags") or []) or "none"
+        notes = (last.get("doctor_notes") or "").strip() or "(none)"
+        last_detail = (
+            f"date: {date}\ntopics: {topics}\nrisk flags: {flags}\n"
+            f"sentiment score: {last.get('sentiment_score')}\nclinician notes: {notes}"
+        )
+        last_transcript = _prior_transcript(pid, last.get("session_id"))
+    else:
+        last_detail = "(no previous session on record)"
+        last_transcript = "(no previous session on record)"
+
+    session_signals = (
+        f"topics so far: {', '.join(active.get('topics') or []) or '—'}\n"
+        f"risk flags so far: {', '.join(active.get('risk_flags') or []) or 'none'}"
+    )
+
+    prompt = DOCTOR_QA_TEMPLATE.format(
+        question=question,
+        patient_summary=build_patient_summary(profile),
+        history_summary=build_history_summary(prior, limit=5),
+        last_session_detail=last_detail,
+        last_session_transcript=last_transcript,
+        live_transcript=_clip_live(transcript),
+        session_signals=session_signals,
+        retrieved_cases=_retrieved_cases(question),
+    )
+
+    try:
+        resp = get_chat_groq().invoke([HumanMessage(content=prompt)])
+        text = resp.content if hasattr(resp, "content") else str(resp)
+        return (text or "").strip() or "I couldn't find an answer in the available record."
+    except Exception:
+        logger.exception("Doctor query answering failed")
+        return ("The assistant is temporarily unavailable (the language model could not be "
+                "reached). Please try again.")

--- a/prompt_templates.py
+++ b/prompt_templates.py
@@ -45,3 +45,31 @@ SESSION_ASSISTANT_TEMPLATE = (
     "- Make uncertainty explicit; prefer fewer high-value items over filler.\n"
     "- Output ONLY the JSON object, with no prose before or after.\n"
 )
+
+
+# Free-form Q&A for the clinician during a live session ("Ask" mode). Plain
+# str.format template (no literal braces). Reused by doctor_qa.py.
+DOCTOR_QA_TEMPLATE = (
+    "You are a QUERY ASSISTANT for a mental-health CLINICIAN during a live session. You answer "
+    "the clinician's question about THIS patient using ONLY the context below. You never address "
+    "the patient.\n\n"
+    "PATIENT RECORD:\n{patient_summary}\n\n"
+    "PRIOR SESSIONS (summary, most recent first):\n{history_summary}\n\n"
+    "MOST RECENT PRIOR SESSION (detail):\n{last_session_detail}\n\n"
+    "MOST RECENT PRIOR SESSION (transcript):\n{last_session_transcript}\n\n"
+    "LIVE SESSION SO FAR (transcript, most recent last):\n{live_transcript}\n\n"
+    "ACCUMULATED SIGNALS THIS SESSION:\n{session_signals}\n\n"
+    "KNOWLEDGE BASE (retrieved counseling cases, for general reference):\n{retrieved_cases}\n\n"
+    "CLINICIAN'S QUESTION:\n{question}\n\n"
+    "RULES:\n"
+    "- Answer ONLY from the context above. If the answer is not in the context, say so plainly "
+    "(e.g. \"the record doesn't contain that\"); never guess or invent details.\n"
+    "- Cite the source inline, e.g. 'from the 2026-05-28 session', 'from the patient record', "
+    "'earlier in today's session', or 'corpus #118'.\n"
+    "- \"The previous session\" means the MOST RECENT PRIOR SESSION blocks above (today's session "
+    "is already excluded).\n"
+    "- Do NOT diagnose, prescribe, or assert medical conclusions. Surface what the record says; "
+    "frame any clinical technique as general reference where clinical judgment applies.\n"
+    "- Be concise: a sentence or a few short markdown bullets. No preamble, no restating the "
+    "question.\n"
+)


### PR DESCRIPTION
## Summary

Adds a third channel to the live-session composer — **Ask** — so the clinician can pose free-form questions during a session and get a concise, **grounded** answer. One general LLM-with-context engine, so it covers arbitrary use cases, e.g.:
- "give me the details about the previous session"
- "summarize this patient's history"
- "what risk flags came up last time"
- "what have we covered so far?"
- "grounding techniques for panic?"

### How it works
- **`doctor_qa.answer_doctor_query(question, active, transcript)`** (new) assembles grounded context — patient summary, prior-sessions summary (**excluding today's in-progress session**), the most-recent prior session's detail **and its archived transcript** (matched by `session_id` from `get_patient_conversations`), the live transcript + accumulated topics/risk-flags, and corpus **RAG** (`semantic_search`) — then asks Groq via the existing `get_chat_groq`, with a graceful fallback. Read-only (no DB writes).
- **`DOCTOR_QA_TEMPLATE`** (new prompt): answer ONLY from context, cite the source/session, say so if unknown, never diagnose/fabricate, concise markdown.
- **`app_chat.py`**: new `doctor_query` branch in the component dispatch loop → returns `{kind:"answer", text}`; guards the PT-0042 demo (no real record).
- **`cockpit_component/index.html`**: third "Ask" segment on the Patient/Doctor toggle; `send()` posts a `doctor_query` and shows an "assistant is thinking…" bubble; `applyServerArgs` resolves it in place as a distinct accent-tinted **Assistant** bubble. Assistant bubbles are filtered **out** of the archived MongoDB conversation.

### Reuse (no new infra)
`model_cache.get_chat_groq` · `semantic_search.semantic_search` · `patient_overview.build_patient_summary`/`build_history_summary`/`_fmt_date`/`_days_ago` · `patient_profile.get_patient_sessions`/`get_patient_conversations` · the existing bidirectional-component bridge.

### Verified live (seeded DB)
Opened **PT-0001**, switched to **Ask**, asked *"give me the details about the previous session"* → grounded Assistant answer citing the most-recent prior session's topics + transcript (correctly **excluding** today's in-progress session); Groq returned `200`; the pending "thinking" bubble resolved.

### Notes
- The PT-0042 scripted demo (no DB-backed record) returns an "open a real patient" message instead of calling the engine.
- LLM/Pinecone failures degrade gracefully (the pending bubble always resolves).

Run: `streamlit run app_chat.py` → open a real patient → **Ask**.