### PR TITLE
Doctor "Ask" assistant — dedicated Q&A panel variant

### DIFF
--- a/app_chat.py
+++ b/app_chat.py
@@ -331,3 +331,23 @@ if isinstance(payload, dict):
                 _archive(active, payload.get("messages"), payload.get("notes", ""), result)
             st.session_state["lsa_result"] = result
             st.rerun()
+
+        elif kind == "doctor_query":
+            # "Ask" mode: answer a clinician's free-form question grounded in the
+            # patient's record + sessions + corpus. Read-only (no archival).
+            active = st.session_state.get("lsa_active")
+            question = (payload.get("question") or "").strip()
+            if not question:
+                text = "Please enter a question for the assistant."
+            elif not active:  # PT-0042 demo opens client-side; no real record loaded
+                text = ("Open a real patient (e.g. PT-0001) to ask record-grounded questions. "
+                        "The scripted PT-0042 demo has no database-backed record.")
+            else:
+                try:
+                    from doctor_qa import answer_doctor_query
+                    text = answer_doctor_query(question, active, payload.get("transcript", ""))
+                except Exception:
+                    logger.exception("Doctor query failed")
+                    text = "The assistant could not answer that just now. Please try again."
+            st.session_state["lsa_result"] = {"nonce": nonce, "kind": "answer", "text": text}
+            st.rerun()

--- a/cockpit_component/index.html
+++ b/cockpit_component/index.html
@@ -331,6 +331,35 @@
     <!-- ===== RIGHT: ASSISTANT ===== -->
     <section class="lsa-scroll" style="overflow-y:auto;min-height:0;display:flex;flex-direction:column;gap:14px;padding-right:4px;">
 
+      <!-- ASK THE ASSISTANT (dedicated Q&A panel, separate from the clinical transcript) -->
+      <div style="background:#fff;border:1px solid #dde3ee;border-radius:11px;padding:16px;">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;">
+          <span style="width:3px;height:13px;border-radius:2px;background:{{ accent }};"></span>
+          <span style="font:600 10.5px/1 'IBM Plex Mono',monospace;letter-spacing:.07em;color:#8a93a8;">ASK THE ASSISTANT</span>
+          <span style="margin-left:auto;font-size:10.5px;color:#aab2c4;">grounded in the record</span>
+        </div>
+        <div style="display:flex;gap:8px;">
+          <input value="{{ askDraft }}" onInput="{{ onAskDraft }}" onKeyDown="{{ onAskKey }}" placeholder="{{ askPlaceholder }}" style="flex:1;min-width:0;border:1px solid #dde3ee;border-radius:8px;padding:10px 11px;font-family:inherit;font-size:13px;color:#1a2235;outline:none;background:#fbfcfe;" />
+          <button onClick="{{ submitAsk }}" style="{{ askSendStyle }}">Ask</button>
+        </div>
+        <sc-if value="{{ hasQa }}" hint-placeholder-val="{{ false }}">
+          <div class="lsa-scroll" style="margin-top:12px;max-height:300px;overflow-y:auto;display:flex;flex-direction:column;gap:10px;">
+            <sc-for list="{{ qaView }}" as="q" hint-placeholder-count="2">
+              <div style="border:1px solid #eef1f6;border-radius:9px;padding:10px 11px;background:#fbfcfe;">
+                <div style="font-size:12px;font-weight:600;color:#3a4458;display:flex;gap:7px;line-height:1.4;"><span style="color:{{ accent }};flex:none;">?</span>{{ q.question }}</div>
+                <sc-if value="{{ q.pending }}" hint-placeholder-val="{{ false }}">
+                  <div style="margin-top:8px;display:flex;align-items:center;gap:7px;animation:softpulse 1.1s ease-in-out infinite;"><span style="width:6px;height:6px;border-radius:50%;background:#aab2c4;"></span><span style="font:500 11px/1 'IBM Plex Mono',monospace;color:#aab2c4;">thinking…</span></div>
+                </sc-if>
+                <sc-if value="{{ q.hasAnswer }}" hint-placeholder-val="{{ true }}">
+                  <div style="margin-top:8px;font-size:12.5px;line-height:1.55;color:#2a3450;white-space:pre-wrap;">{{ q.answer }}</div>
+                </sc-if>
+              </div>
+            </sc-for>
+          </div>
+        </sc-if>
+        <div style="margin-top:11px;padding-top:10px;border-top:1px dashed #e3e8f2;font-size:11px;color:#9aa3b6;line-height:1.45;">Answers are grounded in the patient record, prior sessions, and the corpus — and kept out of the clinical transcript.</div>
+      </div>
+
       <!-- PIPELINE -->
       <sc-if value="{{ showPipeline }}" hint-placeholder-val="{{ true }}">
         <div style="background:#172033;border:1px solid #172033;border-radius:11px;padding:15px 16px;color:#cdd6e8;">
@@ -675,6 +704,8 @@ class Component extends DCLogic {
       launchId: "PT-0042",
       launchError: "",
       loadingPatient: false,
+      askDraft: "",       // "Ask the assistant" panel input
+      qa: [],             // [{id, question, answer, pending}]
       trajectory: [-0.54],
       elapsed: 0,
       stages: this.doneStages(false),
@@ -920,7 +951,20 @@ class Component extends DCLogic {
         patient: r.patient, realTimeline: r.timeline || [],
         messages: [], suggestions: null, why: null, whyOpen: null,
         crisisActive: null, trajectory: [], scriptIndex: this.SCRIPT.length,
+        qa: [], askDraft: "",
         stages: this.stageDefs().map(x => ({ ...x, status: "pending" })), running: false,
+      });
+      return;
+    }
+
+    if (r.kind === "answer") {
+      // Resolve the most recent pending Q&A entry in the Ask panel.
+      this.setState(s => {
+        const qa = s.qa.slice();
+        for (let j = qa.length - 1; j >= 0; j--) {
+          if (qa[j].pending) { qa[j] = { ...qa[j], pending: false, answer: r.text || "(no answer)" }; break; }
+        }
+        return { qa, running: false };
       });
       return;
     }
@@ -975,6 +1019,28 @@ class Component extends DCLogic {
   onLaunchId = (e) => this.setState({ launchId: e.target.value, launchError: "" });
   onLaunchKey = (e) => { if (e.key === "Enter") { e.preventDefault(); this.submitLaunch(); } };
   backToLaunch = () => this.setState({ view: "launch" });
+
+  // ---------- Ask-the-assistant panel ----------
+  onAskDraft = (e) => this.setState({ askDraft: e.target.value });
+  onAskKey = (e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); this.submitAsk(); } };
+  submitAsk = () => {
+    if (this.state.running) return;
+    const q = (this.state.askDraft || "").trim();
+    if (!q) return;
+    const nonce = (this._nonce = (this._nonce || 0) + 1);
+    this._pendingNonce = nonce;
+    const transcript = this.state.messages.map(m => this.cap(m.speaker) + ": " + m.text).join("\n");
+    this.setState(s => ({
+      qa: s.qa.concat([{ id: this.uid(), question: q, answer: "", pending: true }]),
+      askDraft: "", running: true,
+    }));
+    if (window.Streamlit && window.Streamlit.setComponentValue) {
+      window.Streamlit.setComponentValue({ nonce: nonce, kind: "doctor_query", question: q, transcript: transcript });
+    } else {
+      setTimeout(() => this.applyServerArgs({ result: { nonce: nonce, kind: "answer",
+        text: "(demo) The backend isn't connected, so I can't pull the record." } }), 300);
+    }
+  };
 
   whyEffective() {
     if (this.state.whyOpen === null) return !!(this.props.whyExpanded);
@@ -1185,6 +1251,15 @@ class Component extends DCLogic {
       // composer
       draft: s.draft, notes: s.notes,
       patientTabStyle, doctorTabStyle, composerPlaceholder, advanceStyle, advanceHint,
+
+      // ask-the-assistant panel
+      askDraft: s.askDraft,
+      hasQa: (s.qa || []).length > 0,
+      qaView: (s.qa || []).map(q => ({ id: q.id, question: q.question, answer: q.answer,
+        pending: !!q.pending, hasAnswer: !q.pending && !!q.answer })),
+      askPlaceholder: "e.g. details about the previous session",
+      askSendStyle: `cursor:pointer;border:none;background:${accent};color:#fff;font-family:inherit;font-weight:600;font-size:13px;padding:0 15px;border-radius:8px;flex:none;`,
+      onAskDraft: this.onAskDraft, onAskKey: this.onAskKey, submitAsk: this.submitAsk,
 
       // report modal
       reportOpen: s.reportOpen, report,

--- a/doctor_qa.py
+++ b/doctor_qa.py
@@ -1,0 +1,123 @@
+"""Doctor-facing query assistant.
+
+Answers a clinician's free-form question during a live session, grounded in the
+patient record, prior sessions (incl. their archived transcripts, excluding
+today's), the live session so far + accumulated signals, and the RAG knowledge
+corpus. One general LLM-with-context engine — no per-question hardcoding.
+
+Read-only: it never writes to the database. Returns a concise markdown answer.
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+_MAX_LIVE_CHARS = 6000
+_MAX_PRIOR_MSGS = 30
+
+
+def _prior_transcript(pid: str, session_id: str) -> str:
+    """The archived transcript of the patient's most recent prior session."""
+    from patient_profile import get_patient_conversations
+    try:
+        convs = get_patient_conversations(pid)
+    except Exception:
+        logger.exception("Failed to load prior conversations")
+        return "(transcript unavailable)"
+    conv = next((c for c in convs if c.get("session_id") == session_id), None)
+    if not conv:
+        return "(transcript for the previous session is not archived)"
+    lines = []
+    for m in (conv.get("messages") or [])[-_MAX_PRIOR_MSGS:]:
+        speaker = m.get("speaker") or ("patient" if m.get("is_user") else "doctor")
+        lines.append(f"{speaker.capitalize()}: {(m.get('content') or '')[:300]}")
+    return "\n".join(lines) or "(empty transcript)"
+
+
+def _retrieved_cases(question: str) -> str:
+    """Top corpus cases for the question (graceful if Pinecone is unavailable)."""
+    from semantic_search import semantic_search
+    try:
+        cases = semantic_search(question, top_k=3)
+    except Exception:
+        logger.exception("Corpus retrieval failed")
+        return "(knowledge base unavailable)"
+    if not cases:
+        return "(no closely related cases found)"
+    return "\n".join(
+        f"- [corpus #{ex.get('questionID')}] Q: {(ex.get('questionText') or '')[:200]} "
+        f"| A: {(ex.get('answerText') or '')[:300]}"
+        for ex in cases
+    )
+
+
+def _clip_live(transcript: str) -> str:
+    t = transcript or "(no turns logged yet)"
+    if len(t) <= _MAX_LIVE_CHARS:
+        return t
+    return t[:1500] + "\n…[earlier turns omitted]…\n" + t[-4000:]
+
+
+def answer_doctor_query(question: str, active: dict, transcript: str) -> str:
+    """Answer the clinician's question grounded in the patient's data + corpus.
+
+    ``active`` is ``st.session_state['lsa_active']`` =
+    ``{patient_id, session_id, profile(dict), risk_flags, topics}``.
+    """
+    from langchain.schema import HumanMessage
+    from model_cache import get_chat_groq
+    from prompt_templates import DOCTOR_QA_TEMPLATE
+    from patient_profile import get_patient_sessions
+    from patient_overview import build_patient_summary, build_history_summary, _fmt_date, _days_ago
+
+    pid = active.get("patient_id")
+    profile = active.get("profile") or {}
+    cur_session_id = active.get("session_id")
+
+    # Prior sessions, excluding today's in-progress session.
+    try:
+        sessions = get_patient_sessions(pid)
+    except Exception:
+        logger.exception("Failed to load patient sessions")
+        sessions = []
+    prior = [s for s in sessions if s.get("session_id") != cur_session_id]
+
+    last = prior[0] if prior else None
+    if last:
+        ago = _days_ago(last.get("created_at"))
+        date = _fmt_date(last.get("created_at")) + (f" ({ago})" if ago else "")
+        topics = ", ".join(last.get("detected_topics") or []) or "—"
+        flags = ", ".join(last.get("risk_flags") or []) or "none"
+        notes = (last.get("doctor_notes") or "").strip() or "(none)"
+        last_detail = (
+            f"date: {date}\ntopics: {topics}\nrisk flags: {flags}\n"
+            f"sentiment score: {last.get('sentiment_score')}\nclinician notes: {notes}"
+        )
+        last_transcript = _prior_transcript(pid, last.get("session_id"))
+    else:
+        last_detail = "(no previous session on record)"
+        last_transcript = "(no previous session on record)"
+
+    session_signals = (
+        f"topics so far: {', '.join(active.get('topics') or []) or '—'}\n"
+        f"risk flags so far: {', '.join(active.get('risk_flags') or []) or 'none'}"
+    )
+
+    prompt = DOCTOR_QA_TEMPLATE.format(
+        question=question,
+        patient_summary=build_patient_summary(profile),
+        history_summary=build_history_summary(prior, limit=5),
+        last_session_detail=last_detail,
+        last_session_transcript=last_transcript,
+        live_transcript=_clip_live(transcript),
+        session_signals=session_signals,
+        retrieved_cases=_retrieved_cases(question),
+    )
+
+    try:
+        resp = get_chat_groq().invoke([HumanMessage(content=prompt)])
+        text = resp.content if hasattr(resp, "content") else str(resp)
+        return (text or "").strip() or "I couldn't find an answer in the available record."
+    except Exception:
+        logger.exception("Doctor query answering failed")
+        return ("The assistant is temporarily unavailable (the language model could not be "
+                "reached). Please try again.")

--- a/prompt_templates.py
+++ b/prompt_templates.py
@@ -45,3 +45,31 @@ SESSION_ASSISTANT_TEMPLATE = (
     "- Make uncertainty explicit; prefer fewer high-value items over filler.\n"
     "- Output ONLY the JSON object, with no prose before or after.\n"
 )
+
+
+# Free-form Q&A for the clinician during a live session ("Ask" mode). Plain
+# str.format template (no literal braces). Reused by doctor_qa.py.
+DOCTOR_QA_TEMPLATE = (
+    "You are a QUERY ASSISTANT for a mental-health CLINICIAN during a live session. You answer "
+    "the clinician's question about THIS patient using ONLY the context below. You never address "
+    "the patient.\n\n"
+    "PATIENT RECORD:\n{patient_summary}\n\n"
+    "PRIOR SESSIONS (summary, most recent first):\n{history_summary}\n\n"
+    "MOST RECENT PRIOR SESSION (detail):\n{last_session_detail}\n\n"
+    "MOST RECENT PRIOR SESSION (transcript):\n{last_session_transcript}\n\n"
+    "LIVE SESSION SO FAR (transcript, most recent last):\n{live_transcript}\n\n"
+    "ACCUMULATED SIGNALS THIS SESSION:\n{session_signals}\n\n"
+    "KNOWLEDGE BASE (retrieved counseling cases, for general reference):\n{retrieved_cases}\n\n"
+    "CLINICIAN'S QUESTION:\n{question}\n\n"
+    "RULES:\n"
+    "- Answer ONLY from the context above. If the answer is not in the context, say so plainly "
+    "(e.g. \"the record doesn't contain that\"); never guess or invent details.\n"
+    "- Cite the source inline, e.g. 'from the 2026-05-28 session', 'from the patient record', "
+    "'earlier in today's session', or 'corpus #118'.\n"
+    "- \"The previous session\" means the MOST RECENT PRIOR SESSION blocks above (today's session "
+    "is already excluded).\n"
+    "- Do NOT diagnose, prescribe, or assert medical conclusions. Surface what the record says; "
+    "frame any clinical technique as general reference where clinical judgment applies.\n"
+    "- Be concise: a sentence or a few short markdown bullets. No preamble, no restating the "
+    "question.\n"
+)


### PR DESCRIPTION
## Summary

The **dedicated Q&A-panel** variant of the doctor "Ask" assistant — an alternative to the inline "Ask" mode in #27. Same grounded backend; different surface.

Instead of a third composer channel + Assistant bubbles in the transcript, this adds an **"ASK THE ASSISTANT"** card at the top of the right column with its own input and Q&A history. The doctor↔patient **transcript stays pristine** — Q&A never enters it and is never archived. The composer is untouched (Patient/Doctor).

### Shared backend (identical to #27, UX-agnostic)
- `doctor_qa.answer_doctor_query` — assembles patient summary, prior sessions (**excluding today's**), the most-recent prior session's detail + its archived transcript, the live transcript + accumulated signals, and corpus **RAG**, then asks Groq. Read-only.
- `DOCTOR_QA_TEMPLATE`; `app_chat.py` `doctor_query` → `{kind:"answer", text}`.

### Frontend (`cockpit_component/index.html`)
- New **ASK THE ASSISTANT** card: input + Ask button + per-question Q&A history with a "thinking…" state. `qa`/`askDraft` state; `submitAsk` posts a `doctor_query`; `applyServerArgs` `answer` branch resolves the pending Q&A entry. Q&A resets when a new patient opens.

### Verified live (seeded DB)
Opened **PT-0001**, asked *"give me the details about the previous session"* in the panel → grounded answer citing the most-recent prior session's topics + transcript (correctly **excluding** today's), Groq `200`; the **LIVE TRANSCRIPT stayed at 0 turns** (Q&A kept fully separate from the clinical record).

### Choosing between the two
- **#27 (inline "Ask" mode):** chat-like, least new UI, answers appear in the conversation flow.
- **This (dedicated panel):** keeps the clinical transcript clean; Q&A is clearly "meta"; separate scroll/history.

These are mutually exclusive — merge one, close the other.

Run: `streamlit run app_chat.py` → open a real patient → use the **Ask the assistant** panel.