### PR TITLE
Wire a real Groq end-of-session report

### DIFF
--- a/app_chat.py
+++ b/app_chat.py
@@ -351,3 +351,19 @@ if isinstance(payload, dict):
                     text = "The assistant could not answer that just now. Please try again."
             st.session_state["lsa_result"] = {"nonce": nonce, "kind": "answer", "text": text}
             st.rerun()
+
+        elif kind == "report":
+            # End-of-session report: a Groq narrative grounded in the session.
+            active = st.session_state.get("lsa_active")
+            if not active:
+                text = "Open a real patient to generate a record-grounded end-of-session report."
+            else:
+                try:
+                    from session_report import generate_session_report
+                    text = generate_session_report(active, payload.get("transcript", ""),
+                                                   payload.get("notes", ""))
+                except Exception:
+                    logger.exception("Session report failed")
+                    text = "The report could not be generated. Please try again."
+            st.session_state["lsa_result"] = {"nonce": nonce, "kind": "reportText", "text": text}
+            st.rerun()

--- a/cockpit_component/index.html
+++ b/cockpit_component/index.html
@@ -546,6 +546,19 @@
           </div>
 
           <div>
+            <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:9px;">
+              <div style="font-size:10.5px;font-weight:700;color:#8a93a8;letter-spacing:.05em;">CLINICAL SUMMARY · AI-GENERATED</div>
+              <button onClick="{{ regenerateReport }}" style="{{ reportBtnStyle }}">{{ reportBtnLabel }}</button>
+            </div>
+            <sc-if value="{{ reportPending }}" hint-placeholder-val="{{ true }}">
+              <div style="display:flex;align-items:center;gap:7px;animation:softpulse 1.1s ease-in-out infinite;padding:6px 0;"><span style="width:6px;height:6px;border-radius:50%;background:#aab2c4;"></span><span style="font:500 11px/1 'IBM Plex Mono',monospace;color:#aab2c4;">generating clinician summary…</span></div>
+            </sc-if>
+            <sc-if value="{{ hasReportText }}" hint-placeholder-val="{{ false }}">
+              <div style="background:#f7f9fc;border:1px solid #e6eaf2;border-radius:9px;padding:13px;font-size:13px;line-height:1.6;color:#2a3450;white-space:pre-wrap;">{{ reportText }}</div>
+            </sc-if>
+          </div>
+
+          <div>
             <div style="font-size:10.5px;font-weight:700;color:#8a93a8;letter-spacing:.05em;margin-bottom:9px;">CLINICIAN NOTES</div>
             <div style="background:#fbfcfe;border:1px solid #e6eaf2;border-radius:9px;padding:12px;font-size:13px;line-height:1.55;color:#3a4458;white-space:pre-wrap;">{{ report.notes }}</div>
           </div>
@@ -672,6 +685,8 @@ class Component extends DCLogic {
       notes: "",
       crisisActive: null,
       reportOpen: false,
+      reportText: "",      // Groq end-of-session summary (cached for the session)
+      reportPending: false,
       view: "launch",
       launchId: "PT-0042",
       launchError: "",
@@ -904,6 +919,7 @@ class Component extends DCLogic {
       draft: "",
       stages: this.stageDefs().map(x => ({ ...x, status: "pending" })),
       suggestions: null, why: null, whyOpen: null, running: true,
+      reportText: "",  // a new turn invalidates the cached end-of-session report
     }));
     if (window.Streamlit && window.Streamlit.setComponentValue) {
       const msgs = this.state.messages.concat([{ speaker: "patient", text: text }])
@@ -942,6 +958,7 @@ class Component extends DCLogic {
         patient: r.patient, realTimeline: r.timeline || [],
         messages: [], suggestions: null, why: null, whyOpen: null,
         crisisActive: null, trajectory: [], scriptIndex: this.SCRIPT.length,
+        reportText: "", reportPending: false,
         stages: this.stageDefs().map(x => ({ ...x, status: "pending" })), running: false,
       });
       return;
@@ -959,6 +976,11 @@ class Component extends DCLogic {
         }
         return { messages: msgs, running: false };
       });
+      return;
+    }
+
+    if (r.kind === "reportText") {
+      this.setState({ reportText: r.text || "(no summary)", reportPending: false });
       return;
     }
 
@@ -981,8 +1003,23 @@ class Component extends DCLogic {
   setSpeakerDoctor = () => this.setState({ speaker: "doctor" });
   setSpeakerAsk = () => this.setState({ speaker: "ask" });
   toggleWhy = () => this.setState(s => ({ whyOpen: !this.whyEffective() }));
-  openReport = () => this.setState({ reportOpen: true });
+  openReport = () => { this.setState({ reportOpen: true }); this.requestReport(false); };
   closeReport = () => this.setState({ reportOpen: false });
+  requestReport = (force) => {
+    if (this.state.reportPending) return;
+    if (this.state.reportText && !force) return;  // cached for this session
+    const nonce = (this._nonce = (this._nonce || 0) + 1);
+    this._pendingNonce = nonce;
+    const transcript = this.state.messages.map(m => this.cap(m.speaker) + ": " + m.text).join("\n");
+    this.setState({ reportPending: true });
+    if (window.Streamlit && window.Streamlit.setComponentValue) {
+      window.Streamlit.setComponentValue({ nonce: nonce, kind: "report", transcript: transcript, notes: this.state.notes });
+    } else {
+      setTimeout(() => this.applyServerArgs({ result: { nonce: nonce, kind: "reportText",
+        text: "(demo) Connect the backend to generate a clinician summary." } }), 300);
+    }
+  };
+  regenerateReport = () => this.requestReport(true);
   stop = (e) => { e.stopPropagation(); };
 
   openSession = () => {
@@ -1232,6 +1269,11 @@ class Component extends DCLogic {
 
       // report modal
       reportOpen: s.reportOpen, report,
+      reportText: s.reportText, reportPending: s.reportPending,
+      hasReportText: !s.reportPending && !!s.reportText,
+      reportBtnLabel: s.reportText ? "Regenerate" : "Generate",
+      reportBtnStyle: "cursor:pointer;border:1px solid #dde3ee;background:#f4f6fa;color:#3a4458;font-family:inherit;font-weight:600;font-size:11.5px;padding:5px 11px;border-radius:7px;",
+      regenerateReport: this.regenerateReport,
 
       // handlers
       advance: this.advance, send: this.send, onDraft: this.onDraft, onComposerKey: this.onComposerKey,

--- a/prompt_templates.py
+++ b/prompt_templates.py
@@ -73,3 +73,27 @@ DOCTOR_QA_TEMPLATE = (
     "- Be concise: a sentence or a few short markdown bullets. No preamble, no restating the "
     "question.\n"
 )
+
+
+# End-of-session clinician summary. Plain str.format template (no literal
+# braces). Reused by session_report.py.
+REPORT_TEMPLATE = (
+    "You are writing a concise END-OF-SESSION SUMMARY for a mental-health CLINICIAN, from THIS "
+    "live session and the patient's record. It is decision support — NOT a diagnosis or a "
+    "medical record.\n\n"
+    "PATIENT RECORD:\n{patient_summary}\n\n"
+    "PRIOR SESSIONS:\n{history_summary}\n\n"
+    "TOPICS OBSERVED THIS SESSION:\n{topics}\n\n"
+    "RISK FLAGS RAISED THIS SESSION (deterministic crisis screen):\n{risk_flags}\n\n"
+    "CLINICIAN NOTES:\n{notes}\n\n"
+    "SESSION TRANSCRIPT (doctor & patient, most recent last):\n{transcript}\n\n"
+    "Write a structured summary in markdown with exactly these three sections:\n"
+    "**Presentation & key themes** — what the patient brought and the main themes.\n"
+    "**Areas of concern / risk** — explicitly address every risk flag listed above; if there "
+    "are none, say so.\n"
+    "**Suggested follow-up** — concrete points for the clinician to consider next time.\n\n"
+    "RULES:\n"
+    "- Ground everything in the transcript and record above; do not invent facts.\n"
+    "- Do NOT diagnose or prescribe; phrase follow-ups as 'Consider...'.\n"
+    "- Be concise — a few short bullets under each heading.\n"
+)

--- a/session_report.py
+++ b/session_report.py
@@ -1,0 +1,55 @@
+"""End-of-session clinician report.
+
+A Groq-generated, structured clinician-facing summary grounded in the live
+session transcript, the signals accumulated this session (topics + risk flags),
+the patient record, and prior sessions. Decision support — not a diagnosis.
+Read-only: it never writes to the database.
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+_MAX_TRANSCRIPT = 8000
+
+
+def generate_session_report(active: dict, transcript: str, notes: str) -> str:
+    """Return a markdown end-of-session summary for the active patient session."""
+    from langchain.schema import HumanMessage
+    from model_cache import get_chat_groq
+    from prompt_templates import REPORT_TEMPLATE
+    from patient_profile import get_patient_sessions
+    from patient_overview import build_patient_summary, build_history_summary
+
+    active = active or {}
+    profile = active.get("profile") or {}
+    pid = active.get("patient_id")
+    cur_session_id = active.get("session_id")
+
+    try:
+        sessions = get_patient_sessions(pid) if pid else []
+    except Exception:
+        logger.exception("Failed to load sessions for the report")
+        sessions = []
+    prior = [s for s in sessions if s.get("session_id") != cur_session_id]
+
+    t = transcript or "(no turns logged)"
+    if len(t) > _MAX_TRANSCRIPT:
+        t = t[:2000] + "\n…[earlier turns omitted]…\n" + t[-5000:]
+
+    prompt = REPORT_TEMPLATE.format(
+        patient_summary=build_patient_summary(profile),
+        history_summary=build_history_summary(prior, limit=5),
+        topics=", ".join(active.get("topics") or []) or "—",
+        risk_flags=", ".join(active.get("risk_flags") or []) or "none",
+        notes=(notes or "").strip() or "(none)",
+        transcript=t,
+    )
+
+    try:
+        resp = get_chat_groq().invoke([HumanMessage(content=prompt)])
+        text = resp.content if hasattr(resp, "content") else str(resp)
+        return (text or "").strip() or "No summary could be generated for this session."
+    except Exception:
+        logger.exception("Session report generation failed")
+        return ("The report could not be generated right now (the language model was "
+                "unreachable). Please try again.")


### PR DESCRIPTION
## Summary

The **End session & report** modal previously showed only client-computed metrics (topics, risk flags, start/end sentiment, turns, notes). This adds a real, grounded **Groq narrative** alongside them — the structured clinician summary the app was always meant to produce.

### Backend
- **`session_report.generate_session_report(active, transcript, notes)`** (new) assembles the patient summary, prior sessions (**excluding today's**), the session's accumulated topics + risk flags, the clinician notes, and the live transcript → asks Groq for a structured summary: **Presentation & key themes / Areas of concern / risk (addressing every flag) / Suggested follow-up**. Read-only; graceful fallback.
- **`REPORT_TEMPLATE`** (new prompt): grounded, no diagnosis/prescription, concise.
- **`app_chat.py`**: new `report` dispatch branch → `{kind:"reportText", text}`; guards the PT-0042 demo.

### Frontend (`cockpit_component/index.html`)
- Opening the report modal **auto-requests** the summary; a "generating clinician summary…" state, then the narrative renders in a new **CLINICAL SUMMARY · AI-GENERATED** section with a **Generate/Regenerate** button. Cached for the session; invalidated when a new turn is logged or a different patient is opened.

### Reuse
`model_cache.get_chat_groq` · `patient_overview.build_patient_summary`/`build_history_summary` · `patient_profile.get_patient_sessions` · the existing component bridge + `lsa_active`.

### Verified live (seeded DB)
Opened **PT-0001** → **End session & report** → Groq `200` and a grounded three-section summary referencing the patient's real record (sleep/insomnia history, bedtime-routine goal), correctly noting no new topics/flags for the (empty) session.

### Notes
- Independent of the Ask-assistant PRs (#27/#28) — touches a different modal/branch; merges on its own (tiny `app_chat.py` dispatch overlap if Ask merges first).

Run: `streamlit run app_chat.py` → open a real patient → **End session & report**.